### PR TITLE
[Angular - NgRx - SCSS] #67 Ensure kit is setup for CLI

### DIFF
--- a/starters/angular-ngrx-scss/package.json
+++ b/starters/angular-ngrx-scss/package.json
@@ -4,7 +4,7 @@
   "keywords": [
     "angular",
     "ngrx",
-    "scss"
+    "sass"
   ],
   "private": true,
   "version": "0.1.0",


### PR DESCRIPTION
This should close #67 

The only change at the moment is to adjust the SCSS keyword to be sass so it matches the correct logo (since at the moment, we're rolling with the idea that they're the same technology). Otherwise, all the metadata should be there to allow the CLI to work.