### PR TITLE
[Website] Fix Production Build by Changing MobileNavigation Import Path

### DIFF
--- a/packages/website/src/pages/frameworks/index.astro
+++ b/packages/website/src/pages/frameworks/index.astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import TechItem from '../../components/TechItem.astro';
-import MobileNavigation from '../../components/MobileNavigation';
+import MobileNavigation from '../../components/MobileNavigation.tsx';
 import { TECHNOLOGIES } from '../../config';
 import Contributors from '../../components/Contributors.astro';
 import { generateHeaderAnchor } from '../../lib/generateHeaderAnchor';


### PR DESCRIPTION
Resolves #220 

The build for whatever reason expects a '.tsx' for the import path to MobileNavigation. The linter seems upset now after making this fix, but the build now functions as expected.

The change that introduced this regression can be found [here](https://github.com/thisdot/starter.dev/commit/ce393f68efcaa6e2c82085c7f8c2cc973d70397c#diff-164c9e7ead49ac55ce388ddb4647642b45501848d28538006738705f1c0eb81fL4-R4). This regression was not introduced by the merge of the new Ng-NgRx-SCSS starter as we previously thought. Also here are [the build logs](https://us-east-1.console.aws.amazon.com/amplify/home?region=us-east-1#/d2zmkukv1jdnvq/main/48) associated with the aforementioned change. It appears that this got introduced a while back but it got missed.