### PR TITLE
[angular-ngrx-scss] BUG: SCSS logo missing from docs site

### DIFF
--- a/packages/website/src/config.tsx
+++ b/packages/website/src/config.tsx
@@ -170,7 +170,7 @@ export const TECHNOLOGIES = [
     Icon: (props) => <SCIcon {...props} />,
   },
   {
-    key: 'saas',
+    key: 'sass',
     name: 'SASS',
     tags: ['CSS'],
     Icon: (props) => <SaaSIcon {...props} />,


### PR DESCRIPTION
Resolves: #243 
This is just a typo fix.

<img width="1440" alt="Screenshot 2022-06-23 at 03 36 53" src="https://user-images.githubusercontent.com/41862157/175195461-8078a9b7-c0a8-4e7b-88e9-5128e458aa2d.png">
