### PR TITLE
[angular-apollo-tailwind] Bug: running kit from main repo for testing yields broken render

### DIFF
--- a/starters/angular-apollo-tailwind/package.json
+++ b/starters/angular-apollo-tailwind/package.json
@@ -29,9 +29,9 @@
     "@angular/platform-browser": "13.3.0",
     "@angular/platform-browser-dynamic": "13.3.0",
     "@angular/router": "13.3.0",
-    "@apollo/client": "3.0.0",
+    "@apollo/client": "3.6.1",
     "apollo-angular": "3.0.1",
-    "graphql": "16",
+    "graphql": "16.4.0",
     "rxjs": "7.5.0",
     "tslib": "2.3.0",
     "zone.js": "0.11.4"


### PR DESCRIPTION
Resolves #239

Result:

> D:\WORK\copy\starter.dev\starters\angular-apollo-tailwind>yarn
> yarn install v1.22.19
> info No lockfile found.
> [1/4] Resolving packages...
> warning @angular-devkit/build-angular > core-js@3.20.3: core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.
> warning @angular-devkit/build-angular > stylus > css > source-map-resolve@0.6.0: See https://github.com/lydell/source-map-resolve#deprecated
> warning @storybook/addon-essentials > @storybook/addon-controls > @storybook/store > stable@0.1.8: Modern JS already guarantees Array#sort() is a stable sort, so this library 
> is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility
> warning @storybook/addon-essentials > @storybook/addon-docs > @storybook/builder-webpack4 > stable@0.1.8: Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility    
> warning @storybook/addon-essentials > @storybook/addon-docs > @storybook/builder-webpack4 > webpack-dev-middleware > webpack-log > uuid@3.4.0: Please upgrade  to version 7 or 
> higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
> warning @storybook/addon-essentials > @storybook/addon-docs > @storybook/builder-webpack4 > webpack > micromatch > snapdragon > source-map-resolve@0.5.3: See https://github.com/lydell/source-map-resolve#deprecated
> warning @storybook/addon-essentials > @storybook/addon-docs > @storybook/builder-webpack4 > webpack > watchpack > watchpack-chokidar2 > chokidar@2.1.8: Chokidar 2 does not receive security updates since 2019. Upgrade to chokidar 3 with 15x fewer dependencies
> warning @storybook/addon-essentials > @storybook/addon-docs > @storybook/builder-webpack4 > webpack > watchpack > watchpack-chokidar2 > chokidar > fsevents@1.2.13: fsevents 1 
> will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
> warning @storybook/addon-essentials > @storybook/addon-docs > @jest/transform > jest-haste-map > sane@4.1.0: some dependency vulnerabilities fixed, support for node < 10 dropped, and newer ECMAScript syntax/features added
> warning @storybook/addon-essentials > @storybook/addon-docs > @storybook/builder-webpack4 > webpack-hot-middleware > querystring@0.2.1: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
> warning @storybook/addon-essentials > @storybook/addon-docs > @storybook/builder-webpack4 > webpack > node-libs-browser > url > querystring@0.2.0: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
> warning @storybook/addon-essentials > @storybook/addon-docs > @storybook/builder-webpack4 > webpack > micromatch > snapdragon > source-map-resolve > resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
> warning @storybook/addon-essentials > @storybook/addon-docs > @storybook/builder-webpack4 > webpack > micromatch > snapdragon > source-map-resolve > source-map-url@0.4.1: See 
> https://github.com/lydell/source-map-url#deprecated
> warning @storybook/addon-essentials > @storybook/addon-docs > @storybook/builder-webpack4 > webpack > micromatch > snapdragon > source-map-resolve > urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
> warning @storybook/builder-webpack5 > stable@0.1.8: Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility
> [2/4] Fetching packages...
> [3/4] Linking dependencies...
> warning "@apollo/client > use-sync-external-store@1.2.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0 || ^18.0.0".
> warning "@storybook/addon-actions > react-inspector@5.1.1" has unmet peer dependency "react@^16.8.4 || ^17.0.0".
> warning "@storybook/addon-actions > @storybook/api@6.4.22" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
> warning "@storybook/addon-actions > @storybook/api@6.4.22" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
> warning "@storybook/addon-actions > @storybook/addons@6.4.22" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
> warning "@storybook/addon-actions > @storybook/addons@6.4.22" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
> warning "@storybook/addon-actions > @storybook/theming@6.4.22" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
> warning "@storybook/addon-actions > @storybook/theming@6.4.22" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
> warning "@storybook/addon-actions > @storybook/components@6.4.22" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
> warning "@storybook/addon-actions > @storybook/components@6.4.22" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
> warning "@storybook/addon-actions > @storybook/theming > @emotion/core@10.3.1" has unmet peer dependency "react@>=16.3.0".
> warning "@storybook/addon-actions > @storybook/theming > @emotion/styled@10.3.0" has unmet peer dependency "react@>=16.3.0".
> warning "@storybook/addon-actions > @storybook/theming > emotion-theming@10.3.0" has unmet peer dependency "react@>=16.3.0".
> warning "@storybook/addon-links > @storybook/router@6.4.22" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
> warning "@storybook/addon-links > @storybook/router@6.4.22" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
> warning "@storybook/addon-actions > @storybook/components > react-colorful@5.5.1" has unmet peer dependency "react@>=16.8.0".
> warning "@storybook/addon-actions > @storybook/components > react-colorful@5.5.1" has unmet peer dependency "react-dom@>=16.8.0".
> warning "@storybook/addon-actions > @storybook/components > markdown-to-jsx@7.1.7" has unmet peer dependency "react@>= 0.14.0".
> warning "@storybook/addon-actions > @storybook/components > react-popper-tooltip@3.1.1" has unmet peer dependency "react@^16.6.0 || ^17.0.0".
> warning "@storybook/addon-actions > @storybook/components > react-popper-tooltip@3.1.1" has unmet peer dependency "react-dom@^16.6.0 || ^17.0.0".
> warning "@storybook/addon-actions > @storybook/components > react-syntax-highlighter@13.5.3" has unmet peer dependency "react@>= 0.14.0".
> warning "@storybook/addon-actions > @storybook/components > react-textarea-autosize@8.3.4" has unmet peer dependency "react@^16.8.0 || ^17.0.0 || ^18.0.0".
> warning "@storybook/addon-actions > @storybook/theming > @emotion/styled > @emotion/styled-base@10.3.0" has unmet peer dependency "react@>=16.3.0".
> warning "@storybook/addon-actions > @storybook/api > @storybook/router > react-router-dom@6.3.0" has unmet peer dependency "react@>=16.8".
> warning "@storybook/addon-actions > @storybook/api > @storybook/router > react-router-dom@6.3.0" has unmet peer dependency "react-dom@>=16.8".
> warning "@storybook/addon-actions > @storybook/components > react-popper-tooltip > react-popper@2.3.0" has unmet peer dependency "react@^16.8.0 || ^17 || ^18".
> warning "@storybook/addon-actions > @storybook/components > react-popper-tooltip > react-popper@2.3.0" has unmet peer dependency "react-dom@^16.8.0 || ^17 || ^18".
> warning "@storybook/addon-actions > @storybook/api > @storybook/router > react-router@6.3.0" has unmet peer dependency "react@>=16.8".
> warning "@storybook/addon-actions > @storybook/components > react-textarea-autosize > use-composed-ref@1.3.0" has unmet peer dependency "react@^16.8.0 || ^17.0.0 || ^18.0.0". 
> warning "@storybook/addon-actions > @storybook/components > react-textarea-autosize > use-latest@1.2.1" has unmet peer dependency "react@^16.8.0 || ^17.0.0 || ^18.0.0".       
> warning "@storybook/addon-actions > @storybook/components > react-textarea-autosize > use-latest > use-isomorphic-layout-effect@1.1.2" has unmet peer dependency "react@^16.8.0 || ^17.0.0 || ^18.0.0".
> warning "@storybook/addon-essentials > @storybook/addon-docs > @mdx-js/react@1.6.22" has unmet peer dependency "react@^16.13.1 || ^17.0.0".
> warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/builder-webpack4@6.4.22" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
> warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/builder-webpack4@6.4.22" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
> warning " > babel-loader@8.2.5" has unmet peer dependency "webpack@>=2".
> warning "@storybook/builder-webpack5 > @storybook/preview-web@6.4.22" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
> warning "@storybook/builder-webpack5 > @storybook/preview-web@6.4.22" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
> warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/source-loader@6.4.22" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
> warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/source-loader@6.4.22" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
> warning "@storybook/addon-interactions > @storybook/core-common@6.4.22" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
> warning "@storybook/addon-interactions > @storybook/core-common@6.4.22" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
> warning "@storybook/addon-essentials > @storybook/addon-docs > react-element-to-jsx-string@14.3.4" has unmet peer dependency "react@^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1". 
> warning "@storybook/addon-essentials > @storybook/addon-docs > react-element-to-jsx-string@14.3.4" has unmet peer dependency "react-dom@^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1".
> warning "@storybook/builder-webpack5 > @storybook/client-api@6.4.22" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
> warning "@storybook/builder-webpack5 > @storybook/client-api@6.4.22" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
> warning "@storybook/manager-webpack5 > @storybook/ui@6.4.22" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
> warning "@storybook/manager-webpack5 > @storybook/ui@6.4.22" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
> warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/core > @storybook/core-server@6.4.22" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
> warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/core > @storybook/core-server@6.4.22" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".      
> warning "@storybook/manager-webpack5 > @storybook/core-client@6.4.22" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
> warning "@storybook/manager-webpack5 > @storybook/core-client@6.4.22" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
> warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/builder-webpack4 > @storybook/ui > react-draggable@4.4.5" has unmet peer dependency "react@>= 16.3.0".
> warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/builder-webpack4 > @storybook/ui > react-draggable@4.4.5" has unmet peer dependency "react-dom@>= 16.3.0".
> warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/builder-webpack4 > @storybook/ui > downshift@6.1.7" has unmet peer dependency "react@>=16.12.0".     
> warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/builder-webpack4 > @storybook/ui > react-helmet-async@1.3.0" has unmet peer dependency "react@^16.6.0 || ^17.0.0 || ^18.0.0".
> warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/builder-webpack4 > @storybook/ui > react-helmet-async@1.3.0" has unmet peer dependency "react-dom@^16.6.0 || ^17.0.0 || ^18.0.0".
> warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/core > @storybook/core-server > @storybook/manager-webpack4@6.4.22" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
> warning "@storybook/addon-essentials > @storybook/addon-docs > @storybook/core > @storybook/core-server > @storybook/manager-webpack4@6.4.22" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
> warning " > @storybook/angular@6.4.22" has unmet peer dependency "@angular-devkit/architect@>=0.8.9".
> warning " > @storybook/angular@6.4.22" has unmet peer dependency "@angular-devkit/core@^0.6.1 || >=7.0.0".
> warning " > @storybook/builder-webpack5@6.4.22" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
> warning " > @storybook/builder-webpack5@6.4.22" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
> warning " > @storybook/manager-webpack5@6.4.22" has unmet peer dependency "react@^16.8.0 || ^17.0.0".
> warning " > @storybook/manager-webpack5@6.4.22" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0".
> warning "@storybook/testing-library > @storybook/instrumenter > @storybook/addons@6.5.9" has unmet peer dependency "react@^16.8.0 || ^17.0.0 || ^18.0.0".
> warning "@storybook/testing-library > @storybook/instrumenter > @storybook/addons@6.5.9" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0 || ^18.0.0".
> warning "@storybook/testing-library > @storybook/instrumenter > @storybook/addons > @storybook/api@6.5.9" has unmet peer dependency "react@^16.8.0 || ^17.0.0 || ^18.0.0".     
> warning "@storybook/testing-library > @storybook/instrumenter > @storybook/addons > @storybook/api@6.5.9" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0 || ^18.0.0". 
> warning "@storybook/testing-library > @storybook/instrumenter > @storybook/addons > @storybook/router@6.5.9" has unmet peer dependency "react@^16.8.0 || ^17.0.0 || ^18.0.0".  
> warning "@storybook/testing-library > @storybook/instrumenter > @storybook/addons > @storybook/router@6.5.9" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0 || ^18.0.0".
> warning "@storybook/testing-library > @storybook/instrumenter > @storybook/addons > @storybook/theming@6.5.9" has unmet peer dependency "react@^16.8.0 || ^17.0.0 || ^18.0.0". 
> warning "@storybook/testing-library > @storybook/instrumenter > @storybook/addons > @storybook/theming@6.5.9" has unmet peer dependency "react-dom@^16.8.0 || ^17.0.0 || ^18.0.0".
> [4/4] Building fresh packages...
> success Saved lockfile.
> Done in 109.93s.
> 
> D:\WORK\copy\starter.dev\starters\angular-apollo-tailwind>yarn start
> yarn run v1.22.19
> $ ng serve
> ✔ Browser application bundle generation complete.
> 
> Initial Chunk Files   | Names         |  Raw Size
> vendor.js             | vendor        |   2.67 MB |
> polyfills.js          | polyfills     | 301.78 kB |
> styles.css, styles.js | styles        | 185.48 kB |
> main.js               | main          |  26.49 kB |
> runtime.js            | runtime       |   6.54 kB |
> 
>                       | Initial Total |   3.18 MB
> 
> Build at: 2022-07-08T11:24:22.103Z - Hash: b7b96c8a1d679d96 - Time: 24362ms
> 
> ** Angular Live Development Server is listening on localhost:4200, open your browser on http://localhost:4200/ **
> 
> 
> √ Compiled successfully.


![image](https://user-images.githubusercontent.com/31627738/177987253-a8bfa6d4-67eb-4e5e-b438-a9822de2abf7.png)
