### PR TITLE
[angular-apollo-tailwind] fix storybook documentation

### DIFF
--- a/starters/angular-apollo-tailwind/.gitignore
+++ b/starters/angular-apollo-tailwind/.gitignore
@@ -40,3 +40,7 @@ testem.log
 # System files
 .DS_Store
 Thumbs.db
+
+# Auto-Generated
+
+documentation.json

--- a/starters/angular-apollo-tailwind/package.json
+++ b/starters/angular-apollo-tailwind/package.json
@@ -16,6 +16,7 @@
     "lint": "npx eslint \"src/**/*.{js,jsx,ts,tsx,html}\" --quiet --fix",
     "lint:styles": "npx stylelint \"src/**/*.{css,less,sass,scss,sss}\"",
     "format": "npx prettier \"src/**/*.{js,jsx,ts,tsx,html,css,scss}\" --write",
+    "docs:json": "compodoc -p ./tsconfig.json -e json -d .",
     "storybook": "yarn docs:json && start-storybook -p 6006",
     "build-storybook": "yarn docs:json && build-storybook"
   },
@@ -46,6 +47,7 @@
     "@angular/cli": "13.3.3",
     "@angular/compiler-cli": "13.3.0",
     "@babel/core": "7.17.10",
+    "@compodoc/compodoc": "1.1.19",
     "@storybook/addon-actions": "6.4.22",
     "@storybook/addon-essentials": "6.4.22",
     "@storybook/addon-interactions": "6.4.22",


### PR DESCRIPTION
Resolves #270 

Turns out storybook is using compodoc to generate the documentation section. This is super important for storybook to provide value. The docs section in the below screenshot does not render without compodoc so this is a must for storybook to run correctly.

![image](https://user-images.githubusercontent.com/1815379/178998882-c097d62a-a6de-47ea-96e6-5cebecca450b.png)
