### PR TITLE
refactor: Update copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Starter kits should include a set of frameworks, libraries, and essential toolin
 
 Starter kits should include some core libraries and technologies that a new project will need. These pieces should come configured according to best practices and be ready to use togther as a unit.
 
-- Framework?: (Next, Nuxt, SvelteKit, Remix, Vue, Angular, etc)
-- UI: (react)
+- Framework?: (Next, Nuxt, SvelteKit, Remix, etc)
+- Core UI: (React, Vue, Angular, etc)
 - Data Fetching and/or State Management: (redux, ngrx, rxjs, react-query, apollo, etc)
 - Styling: (tailwind, styled-components, css modules, etc)
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Starter kits should include a set of frameworks, libraries, and essential toolin
 
 Starter kits should include some core libraries and technologies that a new project will need. These pieces should come configured according to best practices and be ready to use togther as a unit.
 
-- Framework?: (Next, Nuxt, SvelteKit, Remix, etc)
-- UI: (react, vue, angular, etc)
+- Framework?: (Next, Nuxt, SvelteKit, Remix, Vue, Angular, etc)
+- UI: (react)
 - Data Fetching and/or State Management: (redux, ngrx, rxjs, react-query, apollo, etc)
 - Styling: (tailwind, styled-components, css modules, etc)
 

--- a/packages/website/src/components/Contributors.astro
+++ b/packages/website/src/components/Contributors.astro
@@ -7,15 +7,16 @@ import { REPO_URL } from '../config';
     class="grid grid-cols-5 dark:bg-gray-800 dark:border-gray-700 mt-16 border border-solid border-gray-400 rounded-lg items-center"
   >
     <div class="p-12 col-span-5 lg:col-span-2 lg:text-left text-center">
-      <h1 class="heading-3 mb-8">Build faster. Together</h1>
+      <h1 class="heading-3 mb-8">Build faster together</h1>
       <p class="mb-8 dark:dark-t">
-        Create a PR if you see mistakes, room for improvement, or new
-        opportunities to help dev team.
+        starter.dev is built with the community in mind. If you have ideas for
+        improvement or new kits you'd like to see, please drop us an issue or
+        pull request. We'd love to collaborate with you to enhance this project.
       </p>
       <a
         class="btn btn-lg btn-primary"
         target="_blank"
-        href={`${REPO_URL}/blob/main/CONTRIBUTING.md`}>Contribute</a
+        href={`${REPO_URL}/blob/main/CONTRIBUTING.md`}>Collaborate on starter.dev</a
       >
     </div>
     <div class="hidden h-full col-span-3 lg:block">

--- a/packages/website/src/components/HomeHero.astro
+++ b/packages/website/src/components/HomeHero.astro
@@ -14,7 +14,7 @@ import { TerminalIcon } from '../icons/heroicons';
       <span class="px-2 rounded-lg bg-blue-500 dark:text-white text-white"
         >configured <TerminalIcon className="w-8 h-8 -ml-1.5 mb-0.5 inline"
       /></span>
-      tech stacks
+      kits
     </h2>
   </div>
   <div

--- a/packages/website/src/components/KitActionLinks.astro
+++ b/packages/website/src/components/KitActionLinks.astro
@@ -17,7 +17,7 @@ const { name, inline } = Astro.props;
     href={`${REPO_URL}/tree/main/starters/${name}`}
     target="_blank"
     rel="noopener noreferrer"
-    >Download Kit <GitHubIcon className="h-3.5 w-3.5 inline ml-2.5 mb-px" /></a
+    >View Kit <GitHubIcon className="h-3.5 w-3.5 inline ml-2.5 mb-px" /></a
   >
   <a
     class="link dark:dark-link text-sm"

--- a/packages/website/src/components/KitHero.astro
+++ b/packages/website/src/components/KitHero.astro
@@ -28,7 +28,7 @@ const crumbs = [
       >
         {technologies.map((tech, i) => (
             <span class={cn('hidden text-3xl text-gray-300 font-light', i > 0 && 'lg:inline')}>/</span>
-            <a href={`/frameworks/${tech.key}`} class="group inline-block my-2">
+            <a href={`/kits-by-tool/${tech.key}`} class="group inline-block my-2">
               <TechItem {...tech} />
             </a>
           ))}

--- a/packages/website/src/components/KitItem.astro
+++ b/packages/website/src/components/KitItem.astro
@@ -26,7 +26,7 @@ const { kit } = Astro.props;
       href={`/kits/${kit.name}`}
       class="inline-flex items-center justify-center t-light dark:dark-t group-hover:text-white font-medium"
     >
-      See Kit Details <ArrowRightIcon className="inline w-4 h-4 ml-2" />
+      View Kit  <ArrowRightIcon className="inline w-4 h-4 ml-2" />
     </a>
     <a
       href={`https://github.com/thisdot/starter.dev/tree/main/starters/${kit.name}`}

--- a/packages/website/src/components/KitTechnologies.astro
+++ b/packages/website/src/components/KitTechnologies.astro
@@ -7,7 +7,7 @@ const { technologies } = Astro.props;
   <h1 class="heading-1 font-medium mb-8">Kits with these technologies</h1>
   <div class="not-prose flex flex-col md:flex-row flex-wrap gap-4">
     {technologies.map((tech) => (
-      <a href={`/frameworks/${tech.key}`} class="group inline-block my-2">
+      <a href={`/kits-by-tool/${tech.key}`} class="group inline-block my-2">
         <TechItem {...tech} />
       </a>
     ))}

--- a/packages/website/src/components/NavBar.tsx
+++ b/packages/website/src/components/NavBar.tsx
@@ -62,8 +62,7 @@ export function NavBar({ currentPath }: Props) {
                       rel="noopener noreferrer"
                       className="btn btn-tertiary btn-lg border-gray-600 text-gray-900 hover:bg-gray-100 dark:text-white dark:border-white dark:bg-transparent"
                     >
-                      GitHub Kits Library
-                      <GitHubIcon className="ml-2 text-lg" />
+                      <GitHubIcon className="text-lg" />
                     </a>
                   </div>
                 </div>
@@ -112,8 +111,7 @@ export function NavBar({ currentPath }: Props) {
                 target="_blank"
                 className="btn btn-tertiary btn-lg border-gray-600 text-gray-900 hover:bg-gray-100 dark:text-white dark:border-white dark:bg-transparent"
               >
-                GitHub Kits Library
-                <GitHubIcon className="ml-2 text-lg" />
+                <GitHubIcon className="text-lg" />
               </Disclosure.Button>
             </div>
           </Disclosure.Panel>

--- a/packages/website/src/components/StickyHero.astro
+++ b/packages/website/src/components/StickyHero.astro
@@ -36,7 +36,7 @@ const { name } = Astro.props;
         href={`${REPO_URL}/tree/main/starters/${name}`}
         target="_blank"
         rel="noopener noreferrer"
-        >Download Kit <GitHubIcon className="h-3.5 w-3.5 inline ml-2.5 mb-px"
+        >Save Kit <GitHubIcon className="h-3.5 w-3.5 inline ml-2.5 mb-px"
         /></a
       >
     </div>

--- a/packages/website/src/components/TechStacksSection.astro
+++ b/packages/website/src/components/TechStacksSection.astro
@@ -6,7 +6,7 @@ const kits = parseKits(items);
 ---
 
 <div class="py-8">
-  <h3 class="heading-4 text-center t-dark dark:dark-t-light">Tech Stacks</h3>
+  <h3 class="heading-4 text-center t-dark dark:dark-t-light">Available Kits</h3>
   <div class="max-w-screen-2xl mx-auto my-12">
     <KitList {kits} />
   </div>

--- a/packages/website/src/config.tsx
+++ b/packages/website/src/config.tsx
@@ -76,25 +76,25 @@ export const TECHNOLOGIES = [
   {
     key: 'angular',
     name: 'Angular',
-    tags: ['Framework'],
+    tags: ['Core UI'],
     Icon: (props) => <AngularIcon {...props} />,
   },
   {
     key: 'react',
     name: 'React',
-    tags: ['Component Library'],
+    tags: ['Core UI'],
     Icon: (props) => <ReactIcon {...props} />,
   },
   {
     key: 'svelte',
     name: 'Svelte',
-    tags: ['Component Library'],
+    tags: ['Core UI'],
     Icon: (props) => <SvelteIcon {...props} />,
   },
   {
     key: 'vue',
     name: 'Vue',
-    tags: ['Framework'],
+    tags: ['Core UI'],
     Icon: (props) => <VueIcon {...props} />,
   },
   {

--- a/packages/website/src/config.tsx
+++ b/packages/website/src/config.tsx
@@ -50,8 +50,8 @@ export const SHOWCASE_REPO_URL =
 
 export const HEADER_NAV_ITEMS: NavItem[] = [
   {
-    title: 'Frameworks',
-    href: '/frameworks',
+    title: 'Kits by Tool',
+    href: '/kits-by-tool',
   },
   {
     title: 'Community',
@@ -69,32 +69,32 @@ export const HEADER_NAV_ITEMS: NavItem[] = [
 ];
 
 export const FOOTER_NAV_ITEMS = HEADER_NAV_ITEMS.filter(
-  (x) => x.title !== 'Frameworks'
+  (x) => x.title !== 'Kits by Tool'
 );
 
 export const TECHNOLOGIES = [
   {
     key: 'angular',
     name: 'Angular',
-    tags: ['UI'],
+    tags: ['Framework'],
     Icon: (props) => <AngularIcon {...props} />,
   },
   {
     key: 'react',
     name: 'React',
-    tags: ['UI'],
+    tags: ['Component Library'],
     Icon: (props) => <ReactIcon {...props} />,
   },
   {
     key: 'svelte',
     name: 'Svelte',
-    tags: ['UI'],
+    tags: ['Component Library'],
     Icon: (props) => <SvelteIcon {...props} />,
   },
   {
     key: 'vue',
     name: 'Vue',
-    tags: ['UI'],
+    tags: ['Framework'],
     Icon: (props) => <VueIcon {...props} />,
   },
   {
@@ -142,49 +142,49 @@ export const TECHNOLOGIES = [
   {
     key: 'tailwind',
     name: 'Tailwind',
-    tags: ['CSS'],
+    tags: ['Styling'],
     Icon: (props) => <TailwindIcon {...props} />,
   },
   {
     key: 'material-ui',
     name: 'Material-UI',
-    tags: ['CSS'],
+    tags: ['Styling'],
     Icon: (props) => <MaterialUIIcon {...props} />,
   },
   {
     key: 'vanilla-extract',
     name: 'Vanilla Extract',
-    tags: ['CSS'],
+    tags: ['Styling'],
     Icon: (props) => <VanillaExtractIcon {...props} />,
   },
   {
     key: 'css module',
     name: 'CSS Module',
-    tags: ['CSS'],
+    tags: ['Styling'],
     Icon: (props) => <CSSModuleIcon {...props} />,
   },
   {
     key: 'styled-components',
     name: 'Styled Components',
-    tags: ['CSS'],
+    tags: ['Styling'],
     Icon: (props) => <SCIcon {...props} />,
   },
   {
     key: 'sass',
     name: 'SASS',
-    tags: ['CSS'],
+    tags: ['Styling'],
     Icon: (props) => <SaaSIcon {...props} />,
   },
   {
     key: 'element-ui',
     name: 'Element-UI',
-    tags: ['CSS'],
+    tags: ['Styling'],
     Icon: (props) => <ElementUIIcon {...props} />,
   },
   {
     key: 'bootstrap',
     name: 'Bootstrap',
-    tags: ['CSS'],
+    tags: ['Styling'],
     Icon: (props) => <BootstrapIcon {...props} />,
   },
   {

--- a/packages/website/src/pages/kits-by-tool/[key].astro
+++ b/packages/website/src/pages/kits-by-tool/[key].astro
@@ -34,8 +34,8 @@ const crumbs = [
     title: 'Home',
   },
   {
-    href: '/frameworks',
-    title: 'Frameworks',
+    href: '/kits-by-tool',
+    title: 'Kits by Tool',
   },
   {
     title: tech.name,

--- a/packages/website/src/pages/kits-by-tool/index.astro
+++ b/packages/website/src/pages/kits-by-tool/index.astro
@@ -27,7 +27,7 @@ const sections = technologies.reduce((acc, tech) => {
 ---
 
 <BaseLayout
-  title="Frameworks - starter.dev"
+  title="Kits by Tool - starter.dev"
   description="Lists technologies used through the starter.dev kit collection"
 >
   <MobileNavigation sections={Object.keys(sections)} client:load />
@@ -67,7 +67,7 @@ const sections = technologies.reduce((acc, tech) => {
             <div class="flex flex-wrap items-center justify-start gap-x-4">
               {technologies.map((tech) => (
                 <a
-                  href={`/frameworks/${tech.key}`}
+                  href={`/kits-by-tool/${tech.key}`}
                   class="group inline-block my-2"
                 >
                   <TechItem {...tech} />


### PR DESCRIPTION
#291

## Nav
- [x] Update "Frameworks" in Nav to be "Kits by Tool"
  - [x] Update route to "kits-by-tool"
  - [x] Update page so routing doesn't break
- [x] "Update "GitHub Kits Library" in Nav to just be the Octocat Icon

## Homepage
- [x] Change "Tech Stacks" heading to "Available Kits"
- [x] Change "See Kit Details" on cards to "View KIt"
- [x] "Build faster. Together" -> "Build faster together"
- [x] Change copy in bottom CTA to be:
  > starter.dev is built with the community in mind. If you have ideas for improvement or new kits you'd like to see, please drop us an issue or pull request. We'd love to collaborate with you to enhance this project.
- [x] Change "Contribute" CTA to "Collaborate on starter.dev"

On "Frameworks", now "Kits by Tool"
- [x] Change Angular and Vue to be under Framework, not UI (they really are frameworks)
- [x] Change UI to "Component Library"
- [x] Change "CSS" to "Styling"

Kit page
- [x] "Download Kit" -> View Kit