### PR TITLE
fix: mock console logs

### DIFF
--- a/starters/next-react-query-tailwind/.babelrc
+++ b/starters/next-react-query-tailwind/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["next/babel"],
+  "plugins": []
+}

--- a/starters/next-react-query-tailwind/.eslintrc.json
+++ b/starters/next-react-query-tailwind/.eslintrc.json
@@ -8,7 +8,11 @@
         "**/__tests__/**/*.[jt]s?(x)",
         "**/?(*.)+(spec|test).[jt]s?(x)"
       ],
-      "extends": ["plugin:testing-library/react"]
+      "extends": [
+        "plugin:testing-library/react",
+        "next/babel",
+        "next/core-web-vitals"
+      ]
     }
   ],
   "rules": {}

--- a/starters/next-react-query-tailwind/__mocks__/consoleMock.js
+++ b/starters/next-react-query-tailwind/__mocks__/consoleMock.js
@@ -1,0 +1,43 @@
+const errorMock = jest.spyOn(console, 'error').mockImplementation();
+const warnMock = jest.spyOn(console, 'warn').mockImplementation();
+const infoMock = jest.spyOn(console, 'info').mockImplementation();
+const logMock = jest.spyOn(console, 'log').mockImplementation();
+const clearMock = jest.spyOn(console, 'clear').mockImplementation();
+const assertMock = jest.spyOn(console, 'assert').mockImplementation();
+const countMock = jest.spyOn(console, 'count').mockImplementation();
+const countResetMock = jest.spyOn(console, 'countReset').mockImplementation();
+const debugMock = jest.spyOn(console, 'debug').mockImplementation();
+const dirMock = jest.spyOn(console, 'dir').mockImplementation();
+const dirxmlMock = jest.spyOn(console, 'dirxml').mockImplementation();
+const groupMock = jest.spyOn(console, 'group').mockImplementation();
+const groupCollapsedMock = jest
+  .spyOn(console, 'groupCollapsed')
+  .mockImplementation();
+const groupEndMock = jest.spyOn(console, 'groupEnd').mockImplementation();
+const tableMock = jest.spyOn(console, 'table').mockImplementation();
+const timeMock = jest.spyOn(console, 'time').mockImplementation();
+const timeEndMock = jest.spyOn(console, 'timeEnd').mockImplementation();
+const traceMock = jest.spyOn(console, 'trace').mockImplementation();
+
+const cleanUpMocks = () => {
+  errorMock.mockRestore();
+  warnMock.mockRestore();
+  infoMock.mockRestore();
+  logMock.mockRestore();
+  clearMock.mockRestore();
+  assertMock.mockRestore();
+  countMock.mockRestore();
+  countResetMock.mockRestore();
+  debugMock.mockRestore();
+  dirMock.mockRestore();
+  dirxmlMock.mockRestore();
+  groupMock.mockRestore();
+  groupCollapsedMock.mockRestore();
+  groupEndMock.mockRestore();
+  tableMock.mockRestore();
+  timeMock.mockRestore();
+  timeEndMock.mockRestore();
+  traceMock.mockRestore();
+};
+
+export { cleanUpMocks };

--- a/starters/next-react-query-tailwind/package.json
+++ b/starters/next-react-query-tailwind/package.json
@@ -39,6 +39,7 @@
     "@types/node": "18.0.3",
     "@types/react": "18.0.15",
     "autoprefixer": "10.4.0",
+    "babel-jest": "28.1.3",
     "babel-loader": "8.2.3",
     "eslint": "8.4.1",
     "eslint-config-next": "12.0.7",

--- a/starters/next-react-query-tailwind/src/components/Counter/Counter.test.tsx
+++ b/starters/next-react-query-tailwind/src/components/Counter/Counter.test.tsx
@@ -1,12 +1,17 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { Counter } from './Counter';
+import { cleanUpMocks } from '../../../__mocks__/consoleMock';
+
+afterAll(() => {
+  cleanUpMocks();
+});
 
 describe('Counter', () => {
   it('should initially set 0', () => {
     render(<Counter />);
 
     const displayElement = screen.getByRole('display-element');
-    expect(displayElement).toHaveTextContent('Count: 0');   
+    expect(displayElement).toHaveTextContent('Count: 0');
   });
 
   it('should increase by 1 when clicking button', () => {

--- a/starters/next-react-query-tailwind/src/components/Greeting/Greeting.test.tsx
+++ b/starters/next-react-query-tailwind/src/components/Greeting/Greeting.test.tsx
@@ -3,10 +3,14 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { Greeting } from './Greeting.data';
 import { setupServer, SetupServerApi } from 'msw/node';
 import { rest } from 'msw';
+import { cleanUpMocks } from '../../../__mocks__/consoleMock';
 
 const MOCK_MESSAGE_HELLO = 'Test Message Hello';
 const MOCK_MESSAGE_ERROR = 'Test Message Error';
 
+afterAll(() => {
+  cleanUpMocks();
+});
 describe('Greeting', () => {
   let server: SetupServerApi | null;
 
@@ -15,19 +19,18 @@ describe('Greeting', () => {
     server = null;
   };
 
-  afterEach(() => server?.resetHandlers())
+  afterEach(() => server?.resetHandlers());
   // afterAll(() => server?.close())
 
   describe('positive flow', () => {
-
     beforeAll(() => {
       server = setupServer(
         rest.get('https://api.starter.dev/hello', (req, res, ctx) => {
-          return res(ctx.text(MOCK_MESSAGE_HELLO))
-        }),
-      )
+          return res(ctx.text(MOCK_MESSAGE_HELLO));
+        })
+      );
       server.listen();
-    })
+    });
 
     afterAll(disposeServer);
 
@@ -38,8 +41,10 @@ describe('Greeting', () => {
         </QueryClientProvider>
       );
 
-      const displayMessage = screen.getByRole('display-message')
-      expect(displayMessage).toHaveClass('grow animate-pulse bg-gray-200 rounded-md');
+      const displayMessage = screen.getByRole('display-message');
+      expect(displayMessage).toHaveClass(
+        'grow animate-pulse bg-gray-200 rounded-md'
+      );
     });
 
     it('should see the data after the data loads', async () => {
@@ -50,22 +55,21 @@ describe('Greeting', () => {
       );
 
       expect(await screen.findByText(MOCK_MESSAGE_HELLO)).toBeVisible();
-      const displayMessage = screen.getByRole('display-message')
+      const displayMessage = screen.getByRole('display-message');
       expect(displayMessage).toHaveClass('grow-0');
       expect(displayMessage).toHaveTextContent(MOCK_MESSAGE_HELLO);
     });
   });
 
   describe('negative flow', () => {
-
     afterAll(disposeServer);
 
     it('should show an error message if the API call response contains a message in the body.', async () => {
       server = setupServer(
-        rest.get('https://api.starter.dev/hello',
-          (req, res, ctx) => res(ctx.status(400), ctx.json({ message: MOCK_MESSAGE_ERROR }))
-        ),
-      )
+        rest.get('https://api.starter.dev/hello', (req, res, ctx) =>
+          res(ctx.status(400), ctx.json({ message: MOCK_MESSAGE_ERROR }))
+        )
+      );
       server.listen();
 
       render(
@@ -75,16 +79,16 @@ describe('Greeting', () => {
       );
 
       expect(await screen.findByText(MOCK_MESSAGE_ERROR)).toBeVisible();
-      const errorMessage = screen.getByRole('error-message')
+      const errorMessage = screen.getByRole('error-message');
       expect(errorMessage).toHaveTextContent(MOCK_MESSAGE_ERROR);
     });
 
     it('should show an error message if the API call response does not contain a message in the body.', async () => {
       server = setupServer(
-        rest.get('https://api.starter.dev/hello',
-          (req, res, ctx) => res(ctx.status(404))
-        ),
-      )
+        rest.get('https://api.starter.dev/hello', (req, res, ctx) =>
+          res(ctx.status(404))
+        )
+      );
       server.listen();
 
       render(
@@ -95,7 +99,7 @@ describe('Greeting', () => {
       const MESSAGE_EXPECTED = 'Request error: Not Found';
 
       expect(await screen.findByText(MESSAGE_EXPECTED)).toBeVisible();
-      const errorMessage = screen.getByRole('error-message')
+      const errorMessage = screen.getByRole('error-message');
       expect(errorMessage).toHaveTextContent(MESSAGE_EXPECTED);
     });
   });

--- a/starters/next-react-query-tailwind/src/components/NavigationLink/NavigationLink.test.tsx
+++ b/starters/next-react-query-tailwind/src/components/NavigationLink/NavigationLink.test.tsx
@@ -1,11 +1,15 @@
 import { render, screen } from '@testing-library/react';
 import { NavigationLink } from './NavigationLink';
+import { cleanUpMocks } from '../../../__mocks__/consoleMock';
 
+afterAll(() => {
+  cleanUpMocks();
+});
 describe('NavigationLink', () => {
   it('should have a valid label', () => {
     render(<NavigationLink to="/" label="Return Home" />);
 
     const link = screen.getByRole('link');
-    expect(link).toHaveTextContent('Return Home');   
+    expect(link).toHaveTextContent('Return Home');
   });
 });


### PR DESCRIPTION
Added a consoleMock file to the __mocks__ folder. This is where we can control which console methods we want to mock. There is an exported function to clear all the mocks which we can run after every test. It's setup this way to try and be as DRY as possible and to be scalable across additional tests.

closes https://github.com/thisdot/starter.dev/issues/284