### PR TITLE
fix: make pre-scroll / post-scroll buttons on kit details page consistent

### DIFF
--- a/packages/website/src/components/KitActionLinks.astro
+++ b/packages/website/src/components/KitActionLinks.astro
@@ -12,7 +12,7 @@ const { name, inline } = Astro.props;
   <div class="space-x-4 invisible lg:visible">
     <ShareDropdown client:only />
     <a
-      class="link text-sm dark:dark-link underline"
+      class="link text-sm dark:dark-link hover:underline"
       target="_blank"
       href={`${REPO_URL}/discussions`}>Have a question?</a
     >
@@ -25,11 +25,11 @@ const { name, inline } = Astro.props;
       rel="noopener noreferrer"
     >
       <BriefcaseIcon className="h-3.5 w-3.5 inline ml-0.5 mb-[2px]" /><span
-        class="underline ml-2">View Showcase</span
+        class="hover:underline ml-2">View Showcase</span
       >
     </a>
     <a
-      class={cn('btn btn-primary text-sm mt-3', !inline && 'mt-3.5')}
+      class={cn('btn btn-primary text-sm mt-3 ml-3', !inline && 'mt-3.5')}
       href={`${REPO_URL}/tree/main/starters/${name}`}
       target="_blank"
       rel="noopener noreferrer"

--- a/packages/website/src/components/KitActionLinks.astro
+++ b/packages/website/src/components/KitActionLinks.astro
@@ -8,35 +8,33 @@ import { ShareDropdown } from './ShareDropdown';
 const { name, inline } = Astro.props;
 ---
 
-<div class="">
-  <div class="flex flex-row items-center max-w-screen-2xl mx-auto">
-    <div class="space-x-4 invisible lg:visible">
-      <ShareDropdown client:only />
-      <a
-        class="link text-sm dark:dark-link underline"
-        target="_blank"
-        href={`${REPO_URL}/discussions`}>Have a question?</a
+<div class="flex flex-row items-center max-w-screen-2xl mx-auto">
+  <div class="space-x-4 invisible lg:visible">
+    <ShareDropdown client:only />
+    <a
+      class="link text-sm dark:dark-link underline"
+      target="_blank"
+      href={`${REPO_URL}/discussions`}>Have a question?</a
+    >
+  </div>
+  <div class="ml-auto">
+    <a
+      class="link text-sm dark:dark-link"
+      href={`${SHOWCASE_REPO_URL}/tree/main/${name}`}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <BriefcaseIcon className="h-3.5 w-3.5 inline ml-0.5 mb-[2px]" /><span
+        class="underline ml-2">View Showcase</span
       >
-    </div>
-    <div class="ml-auto">
-      <a
-        class="link text-sm dark:dark-link"
-        href={`${SHOWCASE_REPO_URL}/tree/main/${name}`}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <BriefcaseIcon className="h-3.5 w-3.5 inline ml-0.5 mb-[2px]" /><span
-          class="underline ml-2">View Showcase</span
-        >
-      </a>
-      <a
-        class={cn('btn btn-primary text-sm mt-3', !inline && 'mt-3.5')}
-        href={`${REPO_URL}/tree/main/starters/${name}`}
-        target="_blank"
-        rel="noopener noreferrer"
-        >Download Kit <GitHubIcon className="h-3.5 w-3.5 inline ml-2.5 mb-px"
-        /></a
-      >
-    </div>
+    </a>
+    <a
+      class={cn('btn btn-primary text-sm mt-3', !inline && 'mt-3.5')}
+      href={`${REPO_URL}/tree/main/starters/${name}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      >Download Kit <GitHubIcon className="h-3.5 w-3.5 inline ml-2.5 mb-px"
+      /></a
+    >
   </div>
 </div>

--- a/packages/website/src/components/KitActionLinks.astro
+++ b/packages/website/src/components/KitActionLinks.astro
@@ -4,31 +4,39 @@ import { BriefcaseIcon } from '../icons/heroicons';
 import { GitHubIcon } from '../icons/GitHubIcon.tsx';
 import { ShareIcon } from '../icons/ShareIcon.tsx';
 import { REPO_URL, SHOWCASE_REPO_URL } from '../config.tsx';
+import { ShareDropdown } from './ShareDropdown';
 const { name, inline } = Astro.props;
 ---
 
-<div
-  class={cn(
-    'flex lg:flex-row lg:space-x-6 lg:items-center flex-col-reverse space-y-3 items-start'
-  )}
->
-  <a
-    class={cn('btn btn-primary text-sm mt-3', !inline && 'mt-3.5')}
-    href={`${REPO_URL}/tree/main/starters/${name}`}
-    target="_blank"
-    rel="noopener noreferrer"
-    >Download Kit <GitHubIcon className="h-3.5 w-3.5 inline ml-2.5 mb-px" /></a
-  >
-  <a
-    class="link dark:dark-link text-sm"
-    href={`${SHOWCASE_REPO_URL}/tree/main/${name}`}
-    target="_blank"
-    rel="noopener noreferrer"
-    ><BriefcaseIcon className="h-3.5 w-3.5 inline ml-0.5 mb-[2px]" />
-    <span class="underline ml-2">View Showcase</span>
-  </a>
-  <a class="link dark:text-[#95DFFF] hidden text-sm" href="#"
-    ><ShareIcon className="h-3.5 w-3.5 inline ml-1 mb-[2px]" />
-    <span class="underline ml-2">Share Kit</span></a
-  >
+<div class="">
+  <div class="flex flex-row items-center max-w-screen-2xl mx-auto">
+    <div class="space-x-4 invisible lg:visible">
+      <ShareDropdown client:only />
+      <a
+        class="link text-sm dark:dark-link underline"
+        target="_blank"
+        href={`${REPO_URL}/discussions`}>Have a question?</a
+      >
+    </div>
+    <div class="ml-auto">
+      <a
+        class="link text-sm dark:dark-link"
+        href={`${SHOWCASE_REPO_URL}/tree/main/${name}`}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <BriefcaseIcon className="h-3.5 w-3.5 inline ml-0.5 mb-[2px]" /><span
+          class="underline ml-2">View Showcase</span
+        >
+      </a>
+      <a
+        class={cn('btn btn-primary text-sm mt-3', !inline && 'mt-3.5')}
+        href={`${REPO_URL}/tree/main/starters/${name}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        >Download Kit <GitHubIcon className="h-3.5 w-3.5 inline ml-2.5 mb-px"
+        /></a
+      >
+    </div>
+  </div>
 </div>

--- a/packages/website/src/components/StickyHero.astro
+++ b/packages/website/src/components/StickyHero.astro
@@ -15,7 +15,7 @@ const { name } = Astro.props;
     <div class="space-x-4">
       <ShareDropdown client:only />
       <a
-        class="link text-sm dark:dark-link underline"
+        class="link text-sm dark:dark-link hover:underline"
         target="_blank"
         href={`${REPO_URL}/discussions`}>Have a question?</a
       >
@@ -28,7 +28,7 @@ const { name } = Astro.props;
         rel="noopener noreferrer"
       >
         <BriefcaseIcon className="h-3.5 w-3.5 inline ml-0.5 mb-[2px]" /><span
-          class="underline ml-2">View Showcase</span
+          class="hover:underline ml-2">View Showcase</span
         >
       </a>
       <a

--- a/packages/website/src/styles/global.css
+++ b/packages/website/src/styles/global.css
@@ -6,6 +6,10 @@
   /* Base */
   .link {
     @apply text-brand-500 hover:text-brand-600;
+    text-decoration: none;
+  }
+  .link:hover {
+    text-decoration: underline;
   }
 
   /* Background colors */


### PR DESCRIPTION
#290 

- Made the post-scroll button positions and the pre-scroll button area to match
- Updated the links to not have underline until they are hovered, focused, or active

Loom video demonstration: https://www.loom.com/share/eb1e59eb1430442693f3b492c81adf47
