### PR TITLE
[Nuxt 2 - Pinia - Tailwind] chore: rename Nuxt kit to Nuxt 2

### DIFF
--- a/packages/website/src/config.tsx
+++ b/packages/website/src/config.tsx
@@ -104,6 +104,12 @@ export const TECHNOLOGIES = [
     Icon: (props) => <NextIcon {...props} />,
   },
   {
+    key: 'nuxt 2',
+    name: 'NuxtJS 2',
+    tags: ['Framework'],
+    Icon: (props) => <NuxtIcon {...props} />,
+  },
+  {
     key: 'nuxt',
     name: 'NuxtJS',
     tags: ['Framework'],

--- a/starter-kits.json
+++ b/starter-kits.json
@@ -3,5 +3,6 @@
   "cra-rxjs-styled-components": "Create React App, RxJS and Styled Components",
   "next-react-query-tailwind": "NextJS, React Query, and TailwindCSS",
   "remix-gql-tailwind": "Remix, GQL and TailwindCSS",
-  "vue3-apollo-quasar": "Vue3, Apollo, and Quasar"
+  "vue3-apollo-quasar": "Vue3, Apollo, and Quasar",
+  "nuxt2-pinia-tailwind": "Nuxt 2, Pinia and TailwindCSS"
 }

--- a/starters/nuxt2-pinia-tailwind/README.md
+++ b/starters/nuxt2-pinia-tailwind/README.md
@@ -1,6 +1,6 @@
-# nuxt-pinia-tailwind starter kit
+# nuxt2-pinia-tailwind starter kit
 
-This starter kit features **Nuxt.js**, **Pinia**, and **Tailwind CSS**.
+This starter kit features **Nuxt.js 2**, **Pinia**, and **Tailwind CSS**.
 ## Table of Contents
 
   - [Overview](#overview)
@@ -32,7 +32,7 @@ This starter kit features **Nuxt.js**, **Pinia**, and **Tailwind CSS**.
 
 ### Example Code
 
-In this `starters/nuxt-pinia-tailwind` directory you will find the `TheCounter` and `TheGreeting` directories. 
+In this `starters/nuxt2-pinia-tailwind` directory you will find the `TheCounter` and `TheGreeting` directories. 
 
 The `TheCounter` directory component uses `Pinia` to control the state of the component. The directory contains the following files:
 
@@ -56,20 +56,20 @@ The `TheGreeting` directory component uses `@nuxtjs/axios` to fetch data from th
 npx create-starter-dev
 ```
 
-- Follow the prompts to select the `nuxt-pinia-tailwind` starter kit and name your new project.
+- Follow the prompts to select the `nuxt2-pinia-tailwind` starter kit and name your new project.
 - `cd` into your project directory and run `yarn`.
 - Run `yarn dev` to start the development server.
 - Open your browser to `http://localhost:3000` to see the included example code running.
 
 ### Manual
 
-This requires a download of the entire starter.dev repository and extraction of the `nuxt-pinia-tailwind` kit from the starters directory.
+This requires a download of the entire starter.dev repository and extraction of the `nuxt2-pinia-tailwind` kit from the starters directory.
 
 ```bash
 git clone https://github.com/thisdot/starter.dev.git
 ```
 
-- Copy and rename the `starters/nuxt-pinia-tailwind` directory to the name of your new project.
+- Copy and rename the `starters/nuxt2-pinia-tailwind` directory to the name of your new project.
 - `cd` into your project directory and run `yarn`.
 - Run `yarn dev` to start the development server.
 - Open your browser to `http://localhost:3000` to see the included example code running.

--- a/starters/nuxt2-pinia-tailwind/nuxt.config.js
+++ b/starters/nuxt2-pinia-tailwind/nuxt.config.js
@@ -1,7 +1,7 @@
 export default {
   // Global page headers: https://go.nuxtjs.dev/config-head
   head: {
-    title: 'nuxt-pinia-tailwind starter kit',
+    title: 'nuxt2-pinia-tailwind starter kit',
     htmlAttrs: {
       lang: 'en',
     },

--- a/starters/nuxt2-pinia-tailwind/package.json
+++ b/starters/nuxt2-pinia-tailwind/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "nuxt-pinia-tailwind",
+  "name": "nuxt2-pinia-tailwind",
   "version": "1.0.0",
   "private": true,
-  "description": "Nuxt, Pinia and TailwindCSS",
+  "description": "Nuxt 2, Pinia and TailwindCSS",
   "keywords": [
-    "nuxt",
+    "nuxt 2",
     "pinia",
     "tailwind"
   ],

--- a/starters/nuxt2-pinia-tailwind/pages/index.vue
+++ b/starters/nuxt2-pinia-tailwind/pages/index.vue
@@ -2,7 +2,7 @@
   <div class="flex flex-col justify-center items-center mt-5 gap-2">
     <header class="bg-blue-600 w-3/5 p-4 text-center rounded mb-5">
       <h1 class="text-2xl font-bold text-white">
-        Nuxt, Pinia and TailwindCSS Starter kit
+        Nuxt 2, Pinia and TailwindCSS Starter kit
       </h1>
     </header>
 


### PR DESCRIPTION
Depends on #320 

### Changes

- Changed all references of `Nuxt` to `Nuxt 2`
- Updated `config.tsx` and `starter-kits.json` files

Webpage kit preview:

![image](https://user-images.githubusercontent.com/39612839/194674698-bdad80fc-3605-41d6-82aa-9759720005a3.png)
 