### PR TITLE
[sveltekit-pod] 1. Add store to the project

### DIFF
--- a/starters/svelte-kit-scss/src/routes/store-test/+page.svelte
+++ b/starters/svelte-kit-scss/src/routes/store-test/+page.svelte
@@ -1,0 +1,12 @@
+<script>
+	import { count } from './stores.js';
+	import Incrementer from './Incrementer.svelte';
+	import Decrementer from './Decrementer.svelte';
+	import Resetter from './Resetter.svelte';
+</script>
+
+<h1>The count is {$count}</h1>
+
+<Incrementer/>
+<Decrementer/>
+<Resetter/>

--- a/starters/svelte-kit-scss/src/routes/store-test/Decrementer.svelte
+++ b/starters/svelte-kit-scss/src/routes/store-test/Decrementer.svelte
@@ -1,0 +1,11 @@
+<script>
+	import { count } from './stores.js';
+
+	function decrement() {
+		count.update(n => n - 1);
+	}
+</script>
+
+<button on:click={decrement}>
+	-
+</button>

--- a/starters/svelte-kit-scss/src/routes/store-test/Incrementer.svelte
+++ b/starters/svelte-kit-scss/src/routes/store-test/Incrementer.svelte
@@ -1,0 +1,11 @@
+<script>
+	import { count } from './stores.js';
+
+	function increment() {
+		count.update(n => n + 1);
+	}
+</script>
+
+<button on:click={increment}>
+	+
+</button>

--- a/starters/svelte-kit-scss/src/routes/store-test/Resetter.svelte
+++ b/starters/svelte-kit-scss/src/routes/store-test/Resetter.svelte
@@ -1,0 +1,11 @@
+<script>
+	import { count } from './stores.js';
+
+	function reset() {
+		count.set(0);
+	}
+</script>
+
+<button on:click={reset}>
+	reset
+</button>

--- a/starters/svelte-kit-scss/src/routes/store-test/stores.js
+++ b/starters/svelte-kit-scss/src/routes/store-test/stores.js
@@ -1,0 +1,3 @@
+import { writable } from 'svelte/store';
+
+export const count = writable(0);


### PR DESCRIPTION
Resolves: #385 

Store ships with Sveltekit so no need to add it.
This is just a test and shows how to do counter with stores. This will  be useful for ref: #376  


> # Background
> 
> Each kit should have a provided state manager setup and be configured for usage.
> 
> # Acceptance
> 
> - [x] Add the chosen state management into the Kit
> - [x] make sure the store works succesfully