### PR TITLE
feat: Add Qwik kit to CLI

### DIFF
--- a/starter-kits.json
+++ b/starter-kits.json
@@ -4,5 +4,5 @@
   "next-react-query-tailwind": "NextJS, React Query, and TailwindCSS",
   "remix-gql-tailwind": "Remix, GQL and TailwindCSS",
   "vue3-apollo-quasar": "Vue3, Apollo, and Quasar",
-  "qwik-fetch-tailwind": "Qwik, GraphQL, and TailwindCSS"
+  "qwik-graphql-tailwind": "Qwik, GraphQL, and TailwindCSS"
 }

--- a/starter-kits.json
+++ b/starter-kits.json
@@ -3,5 +3,6 @@
   "cra-rxjs-styled-components": "Create React App, RxJS and Styled Components",
   "next-react-query-tailwind": "NextJS, React Query, and TailwindCSS",
   "remix-gql-tailwind": "Remix, GQL and TailwindCSS",
-  "vue3-apollo-quasar": "Vue3, Apollo, and Quasar"
+  "vue3-apollo-quasar": "Vue3, Apollo, and Quasar",
+  "qwik-fetch-tailwind": "Qwik, GraphQL, and TailwindCSS"
 }

--- a/starters/qwik-graphql-tailwind/package.json
+++ b/starters/qwik-graphql-tailwind/package.json
@@ -6,6 +6,7 @@
     "graphql",
     "tailwind"
   ],
+  "version": "0.0.1",
   "engines": {
     "node": ">=15.0.0"
   },


### PR DESCRIPTION
## Acceptance Criteria

- [X]  Add the kit to the CLI as a setup option
- [ ]  Test it locally with a fresh install

Note: Cannot be tested locally because in order to run `create-starter` is reading the file from  

`const STARTER_KITS_JSON_URL = 'https://raw.githubusercontent.com/thisdot/starter.dev/main/starter-kits.json';`

which is not already in place.

Fixes: #352 