### PR TITLE
[qwik-pod] feat: use graphql queries with fetch

### DIFF
--- a/starters/qwik-graphql-tailwind/src/routes/data-fetching/index.tsx
+++ b/starters/qwik-graphql-tailwind/src/routes/data-fetching/index.tsx
@@ -1,5 +1,4 @@
-import { component$, useStore, Resource, useResource$ } from '@builder.io/qwik';
-import { Link } from '@builder.io/qwik-city';
+import { component$ } from '@builder.io/qwik';
 import { DataFetching } from './data-fetching';
 
 export default component$(() => {

--- a/starters/qwik-graphql-tailwind/src/utils/useQuery.ts
+++ b/starters/qwik-graphql-tailwind/src/utils/useQuery.ts
@@ -1,0 +1,28 @@
+// Inspired by https://github.com/TahaSh/qwikql/blob/main/src/useQuery.ts
+
+import { $ } from '@builder.io/qwik';
+
+export interface QueryOptions {
+  url: string;
+  variables?: Record<string, unknown>;
+  signal?: AbortSignal;
+}
+
+export const useQuery = (query: string) => {
+  const executeQuery$ = $(
+    async ({ url, signal, variables }: QueryOptions) =>
+      await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        signal,
+        body: JSON.stringify({
+          query,
+          variables,
+        }),
+      })
+  );
+
+  return { executeQuery$ };
+};


### PR DESCRIPTION
Closes #346 

- Added `useQuery` that can be used to make GraphQl requests with `fetch` api.
- Refactored fetch example to use GraphQL.
- Removed some unused imports.