### PR TITLE
chore: allow automatic line endings, exclude config files from eslint

### DIFF
--- a/starters/qwik-graphql-tailwind/.eslintignore
+++ b/starters/qwik-graphql-tailwind/.eslintignore
@@ -29,3 +29,5 @@ build
 dist
 tsconfig.tsbuildinfo
 vite.config.ts
+.eslintrc.cjs
+postcss.config.js

--- a/starters/qwik-graphql-tailwind/.prettierrc
+++ b/starters/qwik-graphql-tailwind/.prettierrc
@@ -1,5 +1,6 @@
 {
   "trailingComma": "es5",
   "singleQuote": true,
-  "printWidth": 120
+  "printWidth": 120,
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
Closes #426 

- [x] Allow automatic line endings in prettier (& eslint).
- [x] Exclude .eslintrc.cjs and postcss.config.js from eslint checks.