### PR TITLE
Solidjs use parser for eslint

### DIFF
--- a/starters/solidjs-tanstack-tailwind/package.json
+++ b/starters/solidjs-tanstack-tailwind/package.json
@@ -52,5 +52,10 @@
     "solidjs",
     "tanstack",
     "tailwind"
-  ]
+  ],
+  "pnpm": {
+    "peerDependencyRules": {
+      "ignoreMissing": ["react", "react-dom", "@babel/*"]
+    }
+  }
 }

--- a/starters/solidjs-tanstack-tailwind/package.json
+++ b/starters/solidjs-tanstack-tailwind/package.json
@@ -30,6 +30,7 @@
     "@storybook/core-common": "6.5.0-alpha.61",
     "@solidjs/router": "^0.5.0",
     "@testing-library/jest-dom": "^5.16.5",
+    "@typescript-eslint/parser": "^5.40.1",
     "autoprefixer": "^10.4.12",
     "eslint": "^8.25.0",
     "eslint-plugin-solid": "^0.7.3",
@@ -39,6 +40,7 @@
     "prettier": "^2.7.1",
     "solid-testing-library": "^0.3.0",
     "tailwindcss": "^3.1.8",
+    "typescript": "^4.8.4",
     "vite": "^3.0.9",
     "vite-plugin-solid": "^2.3.0",
     "vitest": "^0.24.3"


### PR DESCRIPTION
eslint needs a parser to understand modern JavaScript. Funny enough the whole Solid stack was built on top of typescript, so it needs Typescript installed to do the correct parsing.

This doesn't imply that we need TS in our own code.