### PR TITLE
[sveltekit-pod] 4. Add the kit to CLI run command

### DIFF
--- a/starters/svelte-kit-scss/package.json
+++ b/starters/svelte-kit-scss/package.json
@@ -6,7 +6,7 @@
     "sass"
   ],
   "private": true,
-  "version": "0.1.0",
+  "version": "0.0.1",
   "scripts": {
     "start": "vite dev --open",
     "dev": "vite dev",


### PR DESCRIPTION
Resolves: #382 

> Background
> At this point, the kit should be fully established and ready for an individual to use via the CLI.
> 
> Acceptance
> - [x] Add the kit to the CLI as a setup option
> - [ ] Test it locally with a fresh install

Updated version of kit from 0.1.0 to 0.0.1