### PR TITLE
chore: loader skeleton

### DIFF
--- a/starters/solidjs-tailwind/src/components/FetchExample/Greeting.jsx
+++ b/starters/solidjs-tailwind/src/components/FetchExample/Greeting.jsx
@@ -6,13 +6,15 @@ const Greeting = () => {
   return (
     <Switch>
       <Match when={message.error}>
-        <p class="text-red-500">There was an error loading your greeting :(</p>
+        <p class="text-red-500">
+          There was an error loading your greeting :(
+        </p>
       </Match>
       <Match when={!message.loading}>
         <p>Message: {message()}</p>
       </Match>
       <Match when={message.loading}>
-        <p>Get ready to be greeted!</p>
+        <div class="w-[80%] lg:w-[20%] mx-auto grow animate-pulse bg-gray-200 rounded-md p-3" />
       </Match>
     </Switch>
   );


### PR DESCRIPTION
In starter.dev we are currently showing a "welcome message" https://github.com/thisdot/starter.dev/pull/431#discussion_r1003152651, but we have to show a skeleton loading as in other kits.