### PR TITLE
fix(#464): hide showcase links for kits with no showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ For proper integration with the starter-dev CLI and website there are also some 
 
 - `description` - This field is used as a short description highlighting the technologies of each particular starter kit. It is shown as a selection in the starter-dev CLI. Example: `NextJS, React Query, and TailwindCSS`
 - `keywords` - This field is an array of strings used to map to the technology list on the starter.dev website. Example: `["next", "react-query", "tailwind"]`
+- `hasShowcase` - This field is a boolean and is required when displaying the "View Showcase" link for kits that have showcases. If your kit has a showcase, set the value to `true`. If your kit does not have a showcase, set the value to `false`.
 
 ### Adding starter kit to the website
 

--- a/packages/website/src/components/KitActionLinks.astro
+++ b/packages/website/src/components/KitActionLinks.astro
@@ -10,7 +10,7 @@ const { name, hasShowcase, inline } = Astro.props;
 
 <div class="flex flex-row items-center max-w-screen-2xl mx-auto">
   <div class="space-x-4 invisible lg:visible">
-    <ShareDropdown client:only />
+    <ShareDropdown kitname={name} client:only />
     <a
       class="link text-sm dark:dark-link hover:underline"
       target="_blank"
@@ -18,17 +18,18 @@ const { name, hasShowcase, inline } = Astro.props;
     >
   </div>
   <div class="ml-auto">
-
-    { !hasShowcase && <a
+    
+    { hasShowcase && (<a
       class="link text-sm dark:dark-link"
       href={`${SHOWCASE_REPO_URL}/tree/main/${name}`}
       target="_blank"
       rel="noopener noreferrer"
     >
       <BriefcaseIcon className="h-3.5 w-3.5 inline ml-0.5 mb-[2px]" /><span
-        class="hover:underline ml-2">View Showcase</span
-      >
-    </a>}
+       class="hover:underline ml-2">View Showcase</span
+        >
+    </a>)}
+
     <a
       class={cn('btn btn-primary text-sm mt-3 ml-3', !inline && 'mt-3.5')}
       href={`${REPO_URL}/tree/main/starters/${name}`}
@@ -36,6 +37,6 @@ const { name, hasShowcase, inline } = Astro.props;
       rel="noopener noreferrer"
       >View Source <GitHubIcon className="h-3.5 w-3.5 inline ml-2.5 mb-px"
       /></a
-    >
+      >
   </div>
 </div>

--- a/packages/website/src/components/KitHero.astro
+++ b/packages/website/src/components/KitHero.astro
@@ -4,7 +4,7 @@ import Breadcrumbs from './Breadcrumbs.astro';
 import KitActionLinks from './KitActionLinks.astro';
 import TechItem from './TechItem.astro';
 
-const { technologies, name } = Astro.props;
+const { technologies, name, hasShowcase } = Astro.props;
 
 const crumbs = [
   {
@@ -36,7 +36,7 @@ const crumbs = [
       <div
         class="py-4 px-8 space-x-4 border-t border-gray-400 dark:border-gray-700"
       >
-        <KitActionLinks {name} inline />
+        <KitActionLinks {name} inline {hasShowcase} />
       </div>
     </div>
   </div>

--- a/packages/website/src/components/StickyHero.astro
+++ b/packages/website/src/components/StickyHero.astro
@@ -21,7 +21,7 @@ const { name, hasShowcase } = Astro.props;
       >
     </div>
     <div class="ml-auto space-x-4">
-      { hasShowcase && <a
+      { hasShowcase && (<a
         class="link text-sm dark:dark-link"
         href={`${SHOWCASE_REPO_URL}/tree/main/${name}`}
         target="_blank"
@@ -30,7 +30,7 @@ const { name, hasShowcase } = Astro.props;
         <BriefcaseIcon className="h-3.5 w-3.5 inline ml-0.5 mb-[2px]" /><span
           class="hover:underline ml-2">View Showcase</span
         >
-      </a>}
+      </a>)}
 
       <a
         class="btn btn-primary text-sm"

--- a/starters/qwik-graphql-tailwind/package.json
+++ b/starters/qwik-graphql-tailwind/package.json
@@ -7,6 +7,7 @@
     "tailwind"
   ],
   "version": "0.0.1",
+  "hasShowcase": false,
   "engines": {
     "node": ">=15.0.0"
   },


### PR DESCRIPTION
This PR closes #464 

"View Showcase" links were previously visible on kits that did not have a showcases. 
Links are now properly rendered based on `hasShowcase` value set in each kit's `package.json` file.

In the example picture below, `qwik-tailwind-graphql` kit does not have a showcase so the link does not display.
<img width="1403" alt="Screen Shot 2022-10-27 at 10 05 02 PM" src="https://user-images.githubusercontent.com/90362911/198536925-3a74cf3a-e505-4971-b6cd-8705cc7ab1a3.png">
