### PR TITLE
add angular ngrx kit to cli, turn off showcase

### DIFF
--- a/starter-kits.json
+++ b/starter-kits.json
@@ -6,5 +6,6 @@
   "svelte-kit-scss": "SvelteKit and SCSS",
   "vue3-apollo-quasar": "Vue3, Apollo, and Quasar",
   "qwik-graphql-tailwind": "Qwik, GraphQL, and TailwindCSS",
-  "solidjs-tailwind": "SolidJs and TailwindCSS"
+  "solidjs-tailwind": "SolidJs and TailwindCSS",
+  "angular-ngrx-scss": "Angular, NgRx, and SCSS"
 }

--- a/starters/angular-ngrx-scss/package.json
+++ b/starters/angular-ngrx-scss/package.json
@@ -8,7 +8,7 @@
   ],
   "private": true,
   "version": "0.1.0",
-  "hasShowcase": true,
+  "hasShowcase": false,
   "scripts": {
     "ng": "ng",
     "start": "ng serve",


### PR DESCRIPTION
We noticed the Angular-NgRx kit was showing on the site but not in the CLI tool. Turns out we were missing the starter-kits command, so this fixes that.

Also turned off the showcase for now, since it's not actually complete. 