### PR TITLE
Fix $lib error when running tests

### DIFF
--- a/starters/svelte-kit-scss/src/lib/components/Counter/Counter.spec.ts
+++ b/starters/svelte-kit-scss/src/lib/components/Counter/Counter.spec.ts
@@ -1,4 +1,4 @@
-import Counter from './Counter.svelte';
+import Counter from '$lib/components/Counter/Counter.svelte';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 
 describe('Counter Component', () => {

--- a/starters/svelte-kit-scss/src/lib/components/Counter/Counter.svelte
+++ b/starters/svelte-kit-scss/src/lib/components/Counter/Counter.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { count, incrementCount, decrementCount, resetCount } from '../../stores';
+  import { count, incrementCount, decrementCount, resetCount } from '$lib/stores';
 
   onMount(resetCount);
 </script>

--- a/starters/svelte-kit-scss/src/lib/components/Greeting/Greeting.spec.ts
+++ b/starters/svelte-kit-scss/src/lib/components/Greeting/Greeting.spec.ts
@@ -1,4 +1,4 @@
-import Greeting from './Greeting.svelte';
+import Greeting from '$lib/components/Greeting/Greeting.svelte';
 import { render } from '@testing-library/svelte';
 
 describe('Greeting Component', () => {

--- a/starters/svelte-kit-scss/vitest.config.ts
+++ b/starters/svelte-kit-scss/vitest.config.ts
@@ -1,10 +1,16 @@
 import { defineConfig } from 'vitest/config';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
+import path from 'path';
 
 export default defineConfig({
   plugins: [svelte({ hot: !process.env.VITEST })],
   test: {
     globals: true,
     environment: 'jsdom',
+  },
+  resolve: {
+    alias: {
+      $lib: path.resolve(__dirname, './src/lib'),
+    },
   },
 });


### PR DESCRIPTION
Resolves #500 

The alias $lib is causing errors when running tests. Find way of adding $lib alias to vitest
