### PR TITLE
feat: adding counter example to NextJS and Chakra UI kit

### DIFF
--- a/starters/next-routing-chakra-ui/package.json
+++ b/starters/next-routing-chakra-ui/package.json
@@ -10,10 +10,10 @@
     "format:fix": "prettier --write --ignore-path .gitignore ."
   },
   "dependencies": {
-    "@chakra-ui/react": "^2.3.5",
-    "@emotion/react": "^11",
-    "@emotion/styled": "^11",
-    "framer-motion": "^6",
+    "@chakra-ui/react": "2.3.5",
+    "@emotion/react": "11",
+    "@emotion/styled": "11",
+    "framer-motion": "6",
     "next": "12.3.1",
     "react": "18.2.0",
     "react-dom": "18.2.0"
@@ -24,7 +24,7 @@
     "@types/react-dom": "18.0.6",
     "eslint": "8.25.0",
     "eslint-config-next": "12.3.1",
-    "prettier": "^2.7.1",
+    "prettier": "2.7.1",
     "typescript": "4.8.4"
   }
 }

--- a/starters/next-routing-chakra-ui/src/pages/_app.tsx
+++ b/starters/next-routing-chakra-ui/src/pages/_app.tsx
@@ -4,8 +4,11 @@ import { extendTheme } from "@chakra-ui/react";
 
 // you can extend the theme and add custom colors, font styles, etc.
 const colors = {
-  navyBlue: "#1a365d",
-  midnightBlue: "#153e75",
+  brand: {
+    50: "#1a365d",
+    100: "#153e75",
+    500: "#2464ec",
+  },
 };
 
 const fontWeights = {

--- a/starters/next-routing-chakra-ui/src/pages/counter-example/index.tsx
+++ b/starters/next-routing-chakra-ui/src/pages/counter-example/index.tsx
@@ -1,8 +1,20 @@
 import type { NextPage } from "next";
 import Link from "next/link";
-import { Center, Heading } from "@chakra-ui/react";
+import { Center, Heading, Button } from "@chakra-ui/react";
+import { SetStateAction, useState } from "react";
 
 const CounterExample: NextPage = () => {
+  const [count, setCount] = useState(0);
+
+  const counterButtons: {
+    text: string;
+    setCounterState: SetStateAction<number>;
+  }[] = [
+    { text: "Increment", setCounterState: count + 1 },
+    { text: "Decrement", setCounterState: count - 1 },
+    { text: "Reset", setCounterState: 0 },
+  ];
+
   return (
     <>
       <Center>
@@ -11,7 +23,21 @@ const CounterExample: NextPage = () => {
         </Heading>
       </Center>
 
-      <div className="">{/*counter goes here*/}</div>
+      <div className="flex justify-evenly whitespace-nowrap">
+        <h2 className="text-2xl font-bold" role="display-element">
+          Count: {count}
+        </h2>
+        {counterButtons.map((btn, idx) => (
+          <Button
+            key={`${idx}-${btn.text}`}
+            onClick={() => setCount(btn.setCounterState)}
+            colorScheme="blue"
+            role="button"
+          >
+            {btn.text}
+          </Button>
+        ))}
+      </div>
       <Center fontSize="xl" textDecoration="underline" color="#376fec">
         <Link href="/">Return Home</Link>
       </Center>

--- a/starters/next-routing-chakra-ui/src/pages/counter-example/index.tsx
+++ b/starters/next-routing-chakra-ui/src/pages/counter-example/index.tsx
@@ -35,7 +35,9 @@ const CounterExample: NextPage = () => {
 
       <Flex justifyContent="space-around" my={8} alignItems="center">
         <Flex alignItems="center">
-          <Heading as="h2">Count:</Heading>
+          <Heading mr={2} as="h2">
+            Count:
+          </Heading>
           <Text fontSize="4xl" color={setColorText()}>
             {count}
           </Text>

--- a/starters/next-routing-chakra-ui/src/pages/counter-example/index.tsx
+++ b/starters/next-routing-chakra-ui/src/pages/counter-example/index.tsx
@@ -1,6 +1,6 @@
 import type { NextPage } from "next";
 import Link from "next/link";
-import { Center, Heading, Button, Stack, Text, Flex } from "@chakra-ui/react";
+import { Center, Heading, Button, Text, Flex } from "@chakra-ui/react";
 import { SetStateAction, useState } from "react";
 
 const CounterExample: NextPage = () => {

--- a/starters/next-routing-chakra-ui/src/pages/counter-example/index.tsx
+++ b/starters/next-routing-chakra-ui/src/pages/counter-example/index.tsx
@@ -1,11 +1,17 @@
-import type { NextPage } from 'next';
-import Link from 'next/link';
-import { Center } from '@chakra-ui/react';
+import type { NextPage } from "next";
+import Link from "next/link";
+import { Center, Heading } from "@chakra-ui/react";
 
-const Counter: NextPage = () => {
+const CounterExample: NextPage = () => {
   return (
     <>
-      This is for the counter example
+      <Center>
+        <Heading as="h1" pb={4} borderBottom="4px solid #2464ec" mt={8}>
+          Increment, Decrement and Reset Button Example
+        </Heading>
+      </Center>
+
+      <div className="">{/*counter goes here*/}</div>
       <Center fontSize="xl" textDecoration="underline" color="#376fec">
         <Link href="/">Return Home</Link>
       </Center>
@@ -13,4 +19,4 @@ const Counter: NextPage = () => {
   );
 };
 
-export default Counter;
+export default CounterExample;

--- a/starters/next-routing-chakra-ui/src/pages/counter-example/index.tsx
+++ b/starters/next-routing-chakra-ui/src/pages/counter-example/index.tsx
@@ -1,6 +1,6 @@
 import type { NextPage } from "next";
 import Link from "next/link";
-import { Center, Heading, Button } from "@chakra-ui/react";
+import { Center, Heading, Button, Stack } from "@chakra-ui/react";
 import { SetStateAction, useState } from "react";
 
 const CounterExample: NextPage = () => {
@@ -23,21 +23,22 @@ const CounterExample: NextPage = () => {
         </Heading>
       </Center>
 
-      <div className="flex justify-evenly whitespace-nowrap">
-        <h2 className="text-2xl font-bold" role="display-element">
-          Count: {count}
-        </h2>
-        {counterButtons.map((btn, idx) => (
+      <Stack direction="row" spacing={8} align="center">
+        <Heading as="h2">Count: {count}</Heading>
+
+        {counterButtons.map(({ text, setCounterState }, idx) => (
           <Button
-            key={`${idx}-${btn.text}`}
-            onClick={() => setCount(btn.setCounterState)}
-            colorScheme="blue"
+            key={`${idx}-${text}`}
+            onClick={() => setCount(setCounterState)}
+            colorScheme="teal"
+            variant="solid"
             role="button"
           >
-            {btn.text}
+            {text}
           </Button>
         ))}
-      </div>
+      </Stack>
+
       <Center fontSize="xl" textDecoration="underline" color="#376fec">
         <Link href="/">Return Home</Link>
       </Center>

--- a/starters/next-routing-chakra-ui/src/pages/counter-example/index.tsx
+++ b/starters/next-routing-chakra-ui/src/pages/counter-example/index.tsx
@@ -1,6 +1,6 @@
 import type { NextPage } from "next";
 import Link from "next/link";
-import { Center, Heading, Button, Stack } from "@chakra-ui/react";
+import { Center, Heading, Button, Stack, Text, Flex } from "@chakra-ui/react";
 import { SetStateAction, useState } from "react";
 
 const CounterExample: NextPage = () => {
@@ -15,6 +15,16 @@ const CounterExample: NextPage = () => {
     { text: "Reset", setCounterState: 0 },
   ];
 
+  const setColorText = () => {
+    if (count === 0) {
+      return "black";
+    } else if (count > 0) {
+      return "green.600";
+    } else {
+      return "red.500";
+    }
+  };
+
   return (
     <>
       <Center>
@@ -23,21 +33,26 @@ const CounterExample: NextPage = () => {
         </Heading>
       </Center>
 
-      <Stack direction="row" spacing={8} align="center">
-        <Heading as="h2">Count: {count}</Heading>
+      <Flex justifyContent="space-around" my={8} alignItems="center">
+        <Flex alignItems="center">
+          <Heading as="h2">Count:</Heading>
+          <Text fontSize="4xl" color={setColorText()}>
+            {count}
+          </Text>
+        </Flex>
 
         {counterButtons.map(({ text, setCounterState }, idx) => (
           <Button
             key={`${idx}-${text}`}
             onClick={() => setCount(setCounterState)}
-            colorScheme="teal"
+            colorScheme="brand"
             variant="solid"
             role="button"
           >
             {text}
           </Button>
         ))}
-      </Stack>
+      </Flex>
 
       <Center fontSize="xl" textDecoration="underline" color="#376fec">
         <Link href="/">Return Home</Link>

--- a/starters/next-routing-chakra-ui/src/pages/fetch-example/[[...slug]].tsx
+++ b/starters/next-routing-chakra-ui/src/pages/fetch-example/[[...slug]].tsx
@@ -1,19 +1,21 @@
-import type { GetServerSideProps, NextPage } from 'next';
-import Link from 'next/link';
-import { Greeting } from '../../components/greeting';
-import { Heading, Center } from '@chakra-ui/react';
+import type { GetServerSideProps, NextPage } from "next";
+import Link from "next/link";
+import { Greeting } from "../../components/greeting";
+import { Heading, Center } from "@chakra-ui/react";
 
 const checkSlugType = (slug: string[] | string | undefined) => {
   if (slug === undefined) {
-    return 'This Dot Labs';
+    return "This Dot Labs";
   }
-  return slug === typeof 'string' ? slug : slug[slug.length - 1];
+  return slug === typeof "string" ? slug : slug[slug.length - 1];
 };
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const { slug } = context.query;
 
-  const res = await fetch(`https://api.starter.dev/hello?greeting=from ${checkSlugType(slug)}!`);
+  const res = await fetch(
+    `https://api.starter.dev/hello?greeting=from ${checkSlugType(slug)}!`
+  );
   const userStr = await res.text();
 
   return {
@@ -25,7 +27,7 @@ const FetchExample: NextPage<{ userStr: string }> = ({ userStr }) => {
   return (
     <div>
       <Center>
-        <Heading pb={4} borderBottom="4px solid #2464ec" mt={8}>
+        <Heading as="h1" pb={4} borderBottom="4px solid #2464ec" mt={8}>
           NextJS 12 Fetching Data From API
         </Heading>
       </Center>

--- a/starters/next-routing-chakra-ui/src/pages/index.tsx
+++ b/starters/next-routing-chakra-ui/src/pages/index.tsx
@@ -1,7 +1,14 @@
-import type { NextPage } from 'next';
-import Head from 'next/head';
-import Link from 'next/link';
-import { Heading, Box, Center, UnorderedList, ListItem, Flex } from '@chakra-ui/react';
+import type { NextPage } from "next";
+import Head from "next/head";
+import Link from "next/link";
+import {
+  Heading,
+  Box,
+  Center,
+  UnorderedList,
+  ListItem,
+  Flex,
+} from "@chakra-ui/react";
 
 type Routes = {
   text: string;
@@ -10,28 +17,47 @@ type Routes = {
 
 const Home: NextPage = () => {
   const routesArr: Routes[] = [
-    { text: 'See Counter example component', route: 'counter-example' },
-    { text: 'See Fetch example component', route: 'fetch-example' },
+    { text: "See Counter example component", route: "counter-example" },
+    { text: "See Fetch example component", route: "fetch-example" },
   ];
 
   return (
     <div>
       <Head>
         <title>NextJS 12 and Chakra UI starter kit</title>
-        <meta name="description" content="This is a starter kit for NextJS 12 and Chakra UI" />
+        <meta
+          name="description"
+          content="This is a starter kit for NextJS 12 and Chakra UI"
+        />
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <Box>
         <Center>
-          <Heading color="white" borderRadius={4} mt={8} p={4} bg="#2464ec">
+          <Heading
+            as="h1"
+            color="white"
+            borderRadius={4}
+            mt={8}
+            p={4}
+            bg="#2464ec"
+          >
             NextJS 12 and Chakra UI Starter Kit
           </Heading>
         </Center>
         <Center>
           <UnorderedList mt={8} listStyleType="none">
-            <Flex flexDirection="column" justifyContent="center" alignItems="center">
+            <Flex
+              flexDirection="column"
+              justifyContent="center"
+              alignItems="center"
+            >
               {routesArr.map(({ route, text }) => (
-                <ListItem key={route} fontSize="2xl" textDecoration="underline" color="#376fec">
+                <ListItem
+                  key={route}
+                  fontSize="2xl"
+                  textDecoration="underline"
+                  color="#376fec"
+                >
                   <Link href={route}>{text}</Link>
                 </ListItem>
               ))}


### PR DESCRIPTION
## Items accomplished in this PR

- [x] added a basic counter component for increment, decrement and reset functionality for the kit
- [x] version controlled the dependencies in the `package.json`
- [x] updated the hex values for the color theme object 
- [x] used prettier to fix formatting inconsistencies 

closes #324 

## Default state
<img width="1389" alt="Screen Shot 2022-11-12 at 5 47 38 PM" src="https://user-images.githubusercontent.com/67210629/201501610-2b5cc9f5-0c4a-4ec3-9fe5-58ed2af44ba9.png">

## Example of decrement functionality 
<img width="1366" alt="Screen Shot 2022-11-12 at 5 48 14 PM" src="https://user-images.githubusercontent.com/67210629/201501630-7f105033-76d6-49c8-a88c-56e2b0dc85f6.png">

## Example of increment functionality 
<img width="1349" alt="Screen Shot 2022-11-12 at 5 48 49 PM" src="https://user-images.githubusercontent.com/67210629/201501646-a9f43c09-3721-44bc-8932-0b5e6114a0e6.png">

