### PR TITLE
fix(#476): add support for removing unwanted fields in package.json for generated kits

### DIFF
--- a/packages/create-starter/src/index.ts
+++ b/packages/create-starter/src/index.ts
@@ -8,6 +8,7 @@ import yargs from 'yargs-parser';
 import { initGitRepo, removeLockFileIfExists, overrideAngularJsonIfExists } from './utils';
 
 const STARTER_KITS_JSON_URL = 'https://raw.githubusercontent.com/thisdot/starter.dev/main/starter-kits.json';
+const EXCLUDED_PACKAGE_JSON_FIELDS = ['hasShowcase'];
 
 export async function main() {
   console.log(`\n${bold('Welcome to starter.dev!')} ${gray('(create-starter)')}`);
@@ -76,6 +77,7 @@ export async function main() {
     const packageJSON = JSON.parse(await fs.readFile(path.join(destPath, 'package.json'), 'utf8'));
     packageJSON.name = options.name;
     packageJSON.version = '0.1.0';
+    EXCLUDED_PACKAGE_JSON_FIELDS.forEach((field) => delete packageJSON[field]);
 
     try {
       await fs.writeFile(path.join(destPath, 'package.json'), JSON.stringify(packageJSON, null, 2));


### PR DESCRIPTION
## Summary
When kits are generated by the user, the `hasShowcase` field also shows up in the `package.json` file. This field is needed in the starter kits but unnecessary for kits generated by the user. This PR provides a solution to exclude the unwanted field. 


## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Documentation change
- [x] Bug fix

## Summary of change

<!-- Please include a brief summary of the changes made in this PR. You should also include any screenshots or videos when applicable -->

## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

- [x] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [ ] This starter kit has been approved by the maintainers
- [ ] Changes for this new starter kit are being pushed to an integration branch instead of main
- [ ] All dependencies are version locked
- [x] This fix resolves #476 
- [x] I have verified the fix works and introduces no further errors


Closes #476 