### PR TITLE
Remove Showcase Links from SvelteKit Kit

### DIFF
--- a/starters/svelte-kit-scss/package.json
+++ b/starters/svelte-kit-scss/package.json
@@ -7,7 +7,7 @@
   ],
   "private": true,
   "version": "0.1.0",
-  "hasShowcase": true,
+  "hasShowcase": false,
   "scripts": {
     "start": "vite dev --open",
     "dev": "vite dev",


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [x] Documentation change
- [ ] Bug fix

## Summary of change
The Showcase is not ready or deployed so the links should be removed from this kit

<!-- Please include a brief summary of the changes made in this PR. You should also include any screenshots or videos when applicable -->

## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

- [x] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
