### PR TITLE
[NODE] feat: added swagger open api generator

### DIFF
--- a/starters/express-typescript-typeorm-postgres/.env.example
+++ b/starters/express-typescript-typeorm-postgres/.env.example
@@ -1,5 +1,7 @@
 # Copy this file into a .env file to make it work in dev mode
 
+NODE_ENV=development
+
 DATABASE_HOST=localhost
 DATABASE_PORT=5432
 DATABASE_USER=postgres

--- a/starters/express-typescript-typeorm-postgres/.gitignore
+++ b/starters/express-typescript-typeorm-postgres/.gitignore
@@ -1,6 +1,8 @@
 # compiled output
 /dist
 /node_modules
+swagger.json
+swagger_v3.json
 
 # database
 pg_data

--- a/starters/express-typescript-typeorm-postgres/README.md
+++ b/starters/express-typescript-typeorm-postgres/README.md
@@ -66,8 +66,7 @@ git clone https://github.com/thisdot/starter.dev.git
 - `cd` into your project directory and run `npm install`.
 - Run `npm run dev` to start the server.
 
-[//]: # (- TODO: #534 this needs to be pointing towards the swagger documentation)
-- Open your browser to `http://localhost:3333/swagger` to see the included example code running.
+- Open your browser to `http://localhost:3333/api-docs` to see the included example code running.
 
 ## Commands
 

--- a/starters/express-typescript-typeorm-postgres/package.json
+++ b/starters/express-typescript-typeorm-postgres/package.json
@@ -70,5 +70,8 @@
     ],
     "coverageDirectory": "../coverage",
     "testEnvironment": "node"
+  },
+  "nodemonConfig": {
+    "ignore": ["**/swagger.json", "**/swagger_v3.json"]
   }
 }

--- a/starters/express-typescript-typeorm-postgres/package.json
+++ b/starters/express-typescript-typeorm-postgres/package.json
@@ -27,8 +27,10 @@
   "dependencies": {
     "dotenv": "^16.0.3",
     "express": "4.18.2",
+    "express-oas-generator": "1.0.45",
     "pg": "8.8.0",
     "reflect-metadata": "^0.1.13",
+    "swagger-ui-express": "4.6.0",
     "typeorm": "0.3.10"
   },
   "devDependencies": {

--- a/starters/express-typescript-typeorm-postgres/src/bootstrap-app.ts
+++ b/starters/express-typescript-typeorm-postgres/src/bootstrap-app.ts
@@ -5,7 +5,6 @@ import { apiRouter } from './controllers/router';
 export function bootstrapApp(): Express {
   const app = express();
   expressOasGenerator.handleResponses(app, {
-    specOutputPath: './swagger.json',
     specOutputFileBehavior: SPEC_OUTPUT_FILE_BEHAVIOR.RECREATE,
     swaggerDocumentOptions: {},
   });

--- a/starters/express-typescript-typeorm-postgres/src/bootstrap-app.ts
+++ b/starters/express-typescript-typeorm-postgres/src/bootstrap-app.ts
@@ -1,9 +1,16 @@
 import express, { Express } from 'express';
+import expressOasGenerator, { SPEC_OUTPUT_FILE_BEHAVIOR } from 'express-oas-generator';
 import { apiRouter } from './controllers/router';
 
 export function bootstrapApp(): Express {
   const app = express();
+  expressOasGenerator.handleResponses(app, {
+    specOutputPath: './swagger.json',
+    specOutputFileBehavior: SPEC_OUTPUT_FILE_BEHAVIOR.RECREATE,
+    swaggerDocumentOptions: {},
+  });
   app.use(express.json());
   app.use('/api', apiRouter);
+  expressOasGenerator.handleRequests();
   return app;
 }


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [X] Feature

## Summary of change

<!-- Please include a brief summary of the changes made in this PR. You should also include any screenshots or videos when applicable -->

Added express-oas-generator to generate proper swagger documentation upon serving the app

Question for reviewers: should we keep the swagger.json and swagger_v3.json files in the repository. I added them to gitignore at this time.

## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

- [x] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [x] This starter kit has been approved by the maintainers
- [x] Changes for this new starter kit are being pushed to an integration branch instead of main
- [x] All dependencies are version locked
- [x] This fix resolves #534 
- [x] I have verified the fix works and introduces no further errors
