### PR TITLE
chore: updating graphql tags in technologies list

### DIFF
--- a/packages/website/src/config.tsx
+++ b/packages/website/src/config.tsx
@@ -99,7 +99,7 @@ export const TECHNOLOGIES = [
     tags: ['Core UI'],
     Icon: (props) => <VueIcon {...props} />,
   },
-   {
+  {
     key: 'solidjs',
     name: 'SolidJs',
     tags: ['Core UI'],
@@ -263,8 +263,8 @@ export const TECHNOLOGIES = [
   },
   {
     key: 'apollo',
-    name: 'Apollo',
-    tags: ['Data Management'],
+    name: 'Apollo Client',
+    tags: ['API Specification'],
     Icon: (props) => <ApolloIcon {...props} />,
   },
   {


### PR DESCRIPTION
## Type of change

- [ ] Documentation change
- [ ] Bug fix
- [x] content change

## Summary of change

### Updated Apollo to say Apollo Client with a tag of API specification 

<img width="546" alt="Screen Shot 2022-12-01 at 3 20 20 PM" src="https://user-images.githubusercontent.com/67210629/205179675-cd4e0188-98ec-421c-b8bf-26b37c537bc5.png">
<img width="988" alt="Screen Shot 2022-12-01 at 3 20 44 PM" src="https://user-images.githubusercontent.com/67210629/205179712-32902d17-a023-4c75-a7d5-42e6343410a2.png">


## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

- [x] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [x] This fix resolves #574 
- [ ] I have verified the fix works and introduces no further errors
