### PR TITLE
fix(website): Remove backticks from inline code MD elements

### DIFF
--- a/packages/website/src/layouts/KitLayout.astro
+++ b/packages/website/src/layouts/KitLayout.astro
@@ -27,7 +27,7 @@ const kit = parseKit(content);
     <NavBar currentPath={path} client:load />
     <KitHero {...kit} />
     <StickyHero {...kit} />
-    <main>
+    <main class="kit-page">
       <MobileNavigation {headers} client:load />
       <div class="toggleDiv grid grid-cols-12 gap-x-8 max-w-screen-2xl mx-auto">
         <aside class="hidden lg:block col-span-3">

--- a/packages/website/src/styles/global.css
+++ b/packages/website/src/styles/global.css
@@ -21,7 +21,7 @@
   }
 
   .show {
-    display: none !important
+    display: none !important;
   }
 
   /* Text colors */
@@ -87,5 +87,11 @@
   /* Links */
   .dark-link {
     @apply text-[#95DFFF];
+  }
+
+  /* OVERRIDES */
+  .kit-page .prose :where(code):not(:where([class~='not-prose'] *)):after,
+  .kit-page .prose :where(code):not(:where([class~='not-prose'] *)):before {
+    content: '';
   }
 }


### PR DESCRIPTION
## Changes
- Updates inline code element style on kit page contents to not include backticks

Closes #599

Before:
![Screen Shot 2022-12-09 at 10 02 56 AM](https://user-images.githubusercontent.com/3721977/206731471-50befb3e-5812-4008-9190-ba497394c6f1.png)

After: 
![Screen Shot 2022-12-09 at 10 03 03 AM](https://user-images.githubusercontent.com/3721977/206731450-a8fdac36-ae97-48cc-8b59-e0fc69d79f8c.png)
