### PR TITLE
fix(svelte-kit-scss): remove alias causing warning from vite.config.ts

### DIFF
--- a/starters/svelte-kit-scss/vite.config.ts
+++ b/starters/svelte-kit-scss/vite.config.ts
@@ -28,12 +28,6 @@ const config: UserConfig & { test: VitestConfig['test'] } = {
     // Exclude playwright tests folder
     exclude: [...configDefaults.exclude, 'tests'],
   },
-
-  resolve: {
-    alias: {
-      $lib: path.resolve(__dirname, './src/lib'),
-    },
-  },
 };
 
 export default config;


### PR DESCRIPTION
## Type of change

- [ ] Documentation change
- [X] Bug fix

## Summary of change

A small change removing the alias that sveltekit was overriding anyway:

<img width="473" alt="Screenshot 2022-12-14 at 1 07 41 PM" src="https://user-images.githubusercontent.com/76821/207690780-096bbd83-7017-40a3-8031-45aca43b46e8.png">


## Checklist
<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

- [x] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [x] I have verified the fix works and introduces no further errors
