### PR TITLE
[sveltekit-pod] Replace svelte-preprocess with vite-preprocess

### DIFF
--- a/starters/svelte-kit-scss/package.json
+++ b/starters/svelte-kit-scss/package.json
@@ -66,12 +66,10 @@
     "svelte": "3.54.0",
     "svelte-check": "2.10.1",
     "svelte-loader": "3.1.4",
-    "svelte-preprocess": "4.10.7",
     "tslib": "2.4.1",
     "typescript": "4.9.3",
     "vite": "4.0.0",
     "vitest": "0.25.4"
   },
-  "type": "module",
-  "dependencies": {}
+  "type": "module"
 }

--- a/starters/svelte-kit-scss/svelte.config.js
+++ b/starters/svelte-kit-scss/svelte.config.js
@@ -1,11 +1,11 @@
 import adapter from '@sveltejs/adapter-auto';
-import preprocess from 'svelte-preprocess';
+import { vitePreprocess } from '@sveltejs/kit/vite';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-  // Consult https://github.com/sveltejs/svelte-preprocess
+  // Consult https://kit.svelte.dev/docs/integrations#preprocessors
   // for more information about preprocessors
-  preprocess: preprocess({ typescript: true, scss: true }),
+  preprocess: vitePreprocess(),
 
   kit: {
     adapter: adapter(),


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Documentation change
- [x] Update

## Summary of change

<!-- Please include a brief summary of the changes made in this PR. You should also include any screenshots or videos when applicable -->

## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

- [x] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [x] This starter kit has been approved by the maintainers
- [ ] Changes for this new starter kit are being pushed to an integration branch instead of main
- [x] All dependencies are version locked
- [x] This fix resolves #778
- [x] I have verified the fix works and introduces no further errors
