### PR TITLE
feat(solidjs-pod): Fix warnings on installation

### DIFF
--- a/starters/solidjs-tailwind/package.json
+++ b/starters/solidjs-tailwind/package.json
@@ -16,6 +16,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "@babel/core": "7.20.5",
     "@solidjs/router": "0.5.0",
     "@storybook/addon-actions": "6.5.13",
     "@storybook/addon-backgrounds": "6.5.13",
@@ -39,6 +40,8 @@
     "msw": "^0.49.2",
     "postcss": "8.4.18",
     "prettier": "2.7.1",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
     "solid-testing-library": "0.3.0",
     "storybook-addon-mock": "3.2.0",
     "tailwindcss": "3.2.1",


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Documentation change
- [x] Bug fix

## Summary of change

- Fix warnings on installation.

Still a few warnings that cannot be fixed:

```
yarn install v1.22.19
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
warning "@storybook/addon-actions > react-inspector@5.1.1" has incorrect peer dependency "react@^16.8.4 || ^17.0.0".
warning "@storybook/addon-docs > @mdx-js/react@1.6.22" has incorrect peer dependency "react@^16.13.1 || ^17.0.0".
warning "@storybook/addon-docs > babel-loader@8.3.0" has unmet peer dependency "webpack@>=2".
warning " > storybook-addon-mock@3.2.0" has unmet peer dependency "@storybook/addons@^6.4.0".
warning " > storybook-addon-mock@3.2.0" has unmet peer dependency "@storybook/api@^6.4.0".
warning " > storybook-addon-mock@3.2.0" has unmet peer dependency "@storybook/components@^6.4.0".
warning " > storybook-addon-mock@3.2.0" has unmet peer dependency "@storybook/theming@^6.4.0".
[4/4] 🔨  Building fresh packages...
success Saved lockfile.
✨  Done in 4.85s.
```

Closes: #740 

