### PR TITLE
[svelte-kit-scss] Storybook should use the main stylesheet as the app

### DIFF
--- a/starters/svelte-kit-scss/.storybook/preview.js
+++ b/starters/svelte-kit-scss/.storybook/preview.js
@@ -1,3 +1,5 @@
+import '/src/routes/styles.scss';
+
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Documentation change
- [x] Bug fix

## Summary of change

<!-- Please include a brief summary of the changes made in this PR. You should also include any screenshots or videos when applicable -->

## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

- [x] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [x] This starter kit has been approved by the maintainers
- [x] Changes for this new starter kit are being pushed to an integration branch instead of main
- [x] All dependencies are version locked
- [x] This fix resolves #803 
- [x] I have verified the fix works and introduces no further errors
