### PR TITLE
test configured, test passed

### DIFF
--- a/starters/solidstart-tanstackquery-tailwind-modules/package.json
+++ b/starters/solidstart-tanstackquery-tailwind-modules/package.json
@@ -13,16 +13,21 @@
   "scripts": {
     "dev": "solid-start dev",
     "build": "solid-start build",
-    "start": "solid-start start"
+    "start": "solid-start start",
+    "test": "vitest"
   },
   "type": "module",
   "devDependencies": {
+    "@testing-library/jest-dom": "^5.16.5",
     "autoprefixer": "^10.4.13",
+    "jsdom": "^21.1.0",
     "postcss": "^8.4.21",
     "solid-start-node": "^0.2.15",
+    "solid-testing-library": "^0.5.0",
     "tailwindcss": "^3.2.4",
     "typescript": "^4.9.4",
-    "vite": "^3.2.5"
+    "vite": "^3.2.5",
+    "vitest": "^0.28.2"
   },
   "dependencies": {
     "@solidjs/meta": "^0.28.2",

--- a/starters/solidstart-tanstackquery-tailwind-modules/src/components/Counter.spec.tsx
+++ b/starters/solidstart-tanstackquery-tailwind-modules/src/components/Counter.spec.tsx
@@ -1,0 +1,15 @@
+import { describe, test, expect } from 'vitest';
+import { fireEvent, render } from 'solid-testing-library'
+import Counter from './Counter';
+
+describe('<Counter />', () => {
+
+  test('Counter mounts', async () => {
+    const { unmount, queryByTestId, getByText } = render(() => <Counter />);
+    const button: any = await queryByTestId('counter_btn')
+    await fireEvent.click(button)
+    const result = await getByText('Clicks: 1');
+    expect(result).toBeTruthy();
+    unmount();
+  });
+})

--- a/starters/solidstart-tanstackquery-tailwind-modules/src/components/Counter.tsx
+++ b/starters/solidstart-tanstackquery-tailwind-modules/src/components/Counter.tsx
@@ -4,6 +4,7 @@ export default function Counter() {
   const [count, setCount] = createSignal(0);
   return (
     <button
+      data-testid="counter_btn"
       class="w-[200px] rounded-full bg-gray-100 border-2 border-gray-300 focus:border-gray-400 active:border-gray-400 px-[2rem] py-[1rem]"
       onClick={() => setCount(count() + 1)}
     >

--- a/starters/solidstart-tanstackquery-tailwind-modules/vite.config.ts
+++ b/starters/solidstart-tanstackquery-tailwind-modules/vite.config.ts
@@ -1,6 +1,22 @@
+/// <reference types="vitest" />
+/// <reference types="vite/client" />
+
 import solid from "solid-start/vite";
 import { defineConfig } from "vite";
 
 export default defineConfig({
   plugins: [solid()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    transformMode: {
+      web: [/.[jt]sx?/],
+    },
+    deps: {
+        inline: [/solid-start/, /solid-testing-library/],
+      },
+    },
+  resolve: {
+    conditions: ['development', 'browser'],
+  },
 });


### PR DESCRIPTION
# Background

Each kit should have a provided a unit testing framework fully installed and configured to be used.

# Acceptance

- [x] Add the chosen testing framework
- [x] When I run yarn test, I should see the tests pass on a simple `expect(true).toBe(true)` test.


## result

![Screenshot 2023-01-27 at 13 27 43](https://user-images.githubusercontent.com/28502531/215087120-750a1eff-9b2e-4dd7-8d20-9cf80f378626.jpg)
