### PR TITLE
[serverless-apollo-contentful] Configure test coverage report to ignore all index.ts files

### DIFF
--- a/starters/serverless-apollo-contentful/jest.config.ts
+++ b/starters/serverless-apollo-contentful/jest.config.ts
@@ -12,6 +12,7 @@ const config: JestConfigWithTsJest = {
 		'/test/',
 		'/mocks/',
 		'/index.ts',
+		'/index.js',
 	],
 	transform: {
 		'\\.[jt]sx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],

--- a/starters/serverless-apollo-contentful/jest.config.ts
+++ b/starters/serverless-apollo-contentful/jest.config.ts
@@ -7,7 +7,12 @@ const config: JestConfigWithTsJest = {
 	collectCoverageFrom: ['src/**/*.ts'],
 	coverageReporters: ['html', 'json', 'lcov', 'text', 'clover'],
 	coverageDirectory: 'coverage',
-	coveragePathIgnorePatterns: ['/node_modules/', '/test/', '/mocks/'],
+	coveragePathIgnorePatterns: [
+		'/node_modules/',
+		'/test/',
+		'/mocks/',
+		'/index.ts',
+	],
 	transform: {
 		'\\.[jt]sx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
 	},


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Documentation change
- [ ] Bug fix

## Summary of change

<!-- Please include a brief summary of the changes made in this PR. You should also include any screenshots or videos when applicable -->

## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

- [ ] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [ ] This starter kit has been approved by the maintainers
- [ ] Changes for this new starter kit are being pushed to an integration branch instead of main
- [ ] All dependencies are version locked
- [ ] This fix resolves #1042
- [ ] I have verified the fix works and introduces no further errors
