### PR TITLE
chore: Warning added to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,5 @@ Currently to add your starter kit to be an available option on the starter.dev C
 ### Starter kit README files
 
 We are still working on defining a general structure and format for starter kit readme files. These are particularly important because the starter kit page on the website is based on the readme files. See: [next12-react-query-tailwind readme content #17](https://github.com/thisdot/starter.dev/pull/17)
+
+**WARNING**: Please do not add any comments to the README files. Comments in the markdown will cause the website builds to fail.


### PR DESCRIPTION
We discovered an issue where having comments included in the kit README files will break the Astro website builds. This PR just adds a comment warning about that issue.