### PR TITLE
[express-apollo-prisma] caching persistence

### DIFF
--- a/starters/express-apollo-prisma/docker-compose.yaml
+++ b/starters/express-apollo-prisma/docker-compose.yaml
@@ -22,14 +22,11 @@ services:
     command:
       - |
         # echo $$DOCKER_REDIS_PASSWORD
-        redis-server --loglevel warning --requirepass $$DOCKER_REDIS_PASSWORD
+        redis-server --save "" --appendonly no --loglevel warning --requirepass $$DOCKER_REDIS_PASSWORD
     ports:
       - $DOCKER_REDIS_PORT_LOCAL:$DOCKER_REDIS_PORT_CONTAINER
     environment:
       - REDIS_REPLICATION_MODE=master
-    volumes:
-      - ./redis:/var/lib/redis
-      - ./redis.conf:/usr/local/etc/redis/redis.conf
     depends_on:
       - mysql
 volumes:

--- a/starters/express-apollo-prisma/docker-compose.yaml
+++ b/starters/express-apollo-prisma/docker-compose.yaml
@@ -27,8 +27,6 @@ services:
       - $DOCKER_REDIS_PORT_LOCAL:$DOCKER_REDIS_PORT_CONTAINER
     environment:
       - REDIS_REPLICATION_MODE=master
-    volumes:
-      - ./redis.conf:/usr/local/etc/redis/redis.conf
     depends_on:
       - mysql
 volumes:

--- a/starters/express-apollo-prisma/docker-compose.yaml
+++ b/starters/express-apollo-prisma/docker-compose.yaml
@@ -22,11 +22,13 @@ services:
     command:
       - |
         # echo $$DOCKER_REDIS_PASSWORD
-        redis-server --save "" --appendonly no --loglevel warning --requirepass $$DOCKER_REDIS_PASSWORD
+        redis-server --loglevel warning --requirepass $$DOCKER_REDIS_PASSWORD
     ports:
       - $DOCKER_REDIS_PORT_LOCAL:$DOCKER_REDIS_PORT_CONTAINER
     environment:
       - REDIS_REPLICATION_MODE=master
+    volumes:
+      - ./redis.conf:/usr/local/etc/redis/redis.conf
     depends_on:
       - mysql
 volumes:


### PR DESCRIPTION
## Type of change

Closes #916 

- [ ] Documentation change
- [ ] Bug fix

## Summary of change

Modify the redis command to start the Redis server without any data persistence, all data will be lost when the server is stopped.

## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

- [ ] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [ ] This starter kit has been approved by the maintainers
- [ ] Changes for this new starter kit are being pushed to an integration branch instead of main
- [ ] All dependencies are version locked
- [ ] This fix resolves #916 
- [ ] I have verified the fix works and introduces no further errors
