### PR TITLE
[express-apollo-prisma] Queueing: Add job generator endpoint

### DIFF
--- a/starters/express-apollo-prisma/src/main.ts
+++ b/starters/express-apollo-prisma/src/main.ts
@@ -22,11 +22,6 @@ if (!REDIS_URL) {
 	throw new Error(`[Invalid environment] Variable not found: REDIS_URL`);
 }
 
-const AMQP_URL = ENV?.AMQP_URL;
-if (!AMQP_URL) {
-	throw new Error(`[Invalid environment] Variable not found: AMQP_URL`);
-}
-
 (async () => {
 	// Required logic for integrating with Express
 	const app = express();

--- a/starters/express-apollo-prisma/src/main.ts
+++ b/starters/express-apollo-prisma/src/main.ts
@@ -50,7 +50,7 @@ if (!AMQP_URL) {
 	const prismaClient = new PrismaClient();
 	app.use('/health', createHealthcheckHandler({ redisClient, prismaClient }));
 	const queueChannel = await createQueueChannel(AMQP_URL);
-	app.post('/example-job', createJobGenerator({ queueChannel }));
+	app.post('/example-job', createJobGeneratorHandler());
 
 	// Modified server startup
 	await new Promise<void>((resolve) => httpServer.listen({ port: PORT }, resolve));

--- a/starters/express-apollo-prisma/src/main.ts
+++ b/starters/express-apollo-prisma/src/main.ts
@@ -7,7 +7,7 @@ import { graphqlServer, createGraphqlServerMiddlewareAsync } from './graphql';
 import * as dotenv from 'dotenv';
 import { connectRedisClient } from './cache/redis';
 import { createHealthcheckHandler } from './healthcheck';
-import { createJobGenerator, createQueueChannel } from './queue/producer';
+import { createJobGeneratorHandler } from './queue/job-generator-handler';
 import { PrismaClient } from '@prisma/client';
 
 const { parsed: ENV } = dotenv.config();
@@ -44,7 +44,6 @@ if (!REDIS_URL) {
 	app.use('/graphql', await createGraphqlServerMiddlewareAsync());
 	const prismaClient = new PrismaClient();
 	app.use('/health', createHealthcheckHandler({ redisClient, prismaClient }));
-	const queueChannel = await createQueueChannel(AMQP_URL);
 	app.post('/example-job', createJobGeneratorHandler());
 
 	// Modified server startup

--- a/starters/express-apollo-prisma/src/queue/job-generator-handler.ts
+++ b/starters/express-apollo-prisma/src/queue/job-generator-handler.ts
@@ -1,9 +1,11 @@
 import { Request, RequestHandler, Response } from 'express';
 import amqplib from 'amqplib';
 
-const AMQP_URL = process.env.AMQP_URL || 'amqp://localhost:5673';
-
 export const createJobGeneratorHandler = (): RequestHandler<Record<string, never>, string> => {
+        const AMQP_URL = process.env.AMQP_URL;
+        if (!AMQP_URL) {
+	        throw new Error(`[Invalid environment] Variable not found: AMQP_URL`);
+        }
 	const queueChannelPromise = createQueueChannel(AMQP_URL);
 
 	return async (req: Request, res: Response) => {

--- a/starters/express-apollo-prisma/src/queue/job-generator-handler.ts
+++ b/starters/express-apollo-prisma/src/queue/job-generator-handler.ts
@@ -2,10 +2,10 @@ import { Request, RequestHandler, Response } from 'express';
 import amqplib from 'amqplib';
 
 export const createJobGeneratorHandler = (): RequestHandler<Record<string, never>, string> => {
-        const AMQP_URL = process.env.AMQP_URL;
-        if (!AMQP_URL) {
-	        throw new Error(`[Invalid environment] Variable not found: AMQP_URL`);
-        }
+	const AMQP_URL = process.env.AMQP_URL;
+	if (!AMQP_URL) {
+		throw new Error(`[Invalid environment] Variable not found: AMQP_URL`);
+	}
 	const queueChannelPromise = createQueueChannel(AMQP_URL);
 
 	return async (req: Request, res: Response) => {

--- a/starters/express-apollo-prisma/src/queue/producer.ts
+++ b/starters/express-apollo-prisma/src/queue/producer.ts
@@ -1,11 +1,9 @@
 import { Request, RequestHandler, Response } from 'express';
 import amqplib from 'amqplib';
 
-export const createJobGenerator = ({
-	queueChannel,
-}: {
-	queueChannel: amqplib.Channel;
-}): RequestHandler<Record<string, never>, string> => {
+// rename the function for readability and clarity
+export const createJobGeneratorHandler = (): RequestHandler<Record<string, never>, string> => {
+       // use [SNIPPET#1] here + create channel here (before return)
 	return async (req: Request, res: Response) => {
 		try {
 			const queue = 'DEMOQUEUE';
@@ -25,7 +23,8 @@ export const createJobGenerator = ({
 	};
 };
 
-export const createQueueChannel = async (amqpUrl: string) => {
+// remove export. it should be encapsulated here to make the Queueing feature optional
+const createQueueChannel = async (amqpUrl: string) => {
 	const connection = await amqplib.connect(amqpUrl, 'heartbeat=60');
 	const channel = await connection.createChannel();
 	return channel;

--- a/starters/express-apollo-prisma/src/queue/producer.ts
+++ b/starters/express-apollo-prisma/src/queue/producer.ts
@@ -1,0 +1,32 @@
+import { Request, RequestHandler, Response } from 'express';
+import amqplib from 'amqplib';
+
+export const createJobGenerator = ({
+	queueChannel,
+}: {
+	queueChannel: amqplib.Channel;
+}): RequestHandler<Record<string, never>, string> => {
+	return async (req: Request, res: Response) => {
+		try {
+			const queue = 'DEMOQUEUE';
+			const exchange = 'QUEUE_ACTION';
+			const routingKey = 'QUEUE_KEY';
+
+			await queueChannel.assertExchange(exchange, 'direct', { durable: true });
+			await queueChannel.assertQueue(queue, { durable: true });
+			await queueChannel.bindQueue(queue, exchange, routingKey);
+
+			const { message } = req.body;
+			queueChannel.publish(exchange, routingKey, Buffer.from(JSON.stringify(message)));
+			res.status(200).send('Message published');
+		} catch (e) {
+			res.status(500).send('Unable to publish message to queue');
+		}
+	};
+};
+
+export const createQueueChannel = async (amqpUrl: string) => {
+	const connection = await amqplib.connect(amqpUrl, 'heartbeat=60');
+	const channel = await connection.createChannel();
+	return channel;
+};


### PR DESCRIPTION
## Type of change

Closes #1085 

- [ ] Documentation change
- [ ] Bug fix

## Summary of change

Adds a POST /example-job endpoint that receives a message and adds it as a job to the queue to be processed.

## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

- [ ] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [ ] This starter kit has been approved by the maintainers
- [ ] Changes for this new starter kit are being pushed to an integration branch instead of main
- [ ] All dependencies are version locked
- [x] This fix resolves #1085 
- [ ] I have verified the fix works and introduces no further errors
