### PR TITLE
bump/open package dependency

### DIFF
--- a/starters/solidjs-tailwind/package.json
+++ b/starters/solidjs-tailwind/package.json
@@ -24,7 +24,7 @@
     "lint-fix": "eslint --ext .js,.jsx ./src --fix",
     "format": "prettier --write ./src --ignore-path .gitignore",
     "storybook": "start-storybook",
-    "prepare": "husky install starters/solidjs-tailwind/.husky"
+    "prepare": "cd .. && cd .. && husky install starters/solidjs-tailwind/.husky"
   },
   "license": "MIT",
   "devDependencies": {

--- a/starters/solidjs-tailwind/package.json
+++ b/starters/solidjs-tailwind/package.json
@@ -24,7 +24,7 @@
     "lint-fix": "eslint --ext .js,.jsx ./src --fix",
     "format": "prettier --write ./src --ignore-path .gitignore",
     "storybook": "start-storybook",
-    "prepare": "cd .. && cd .. && husky install starters/solidjs-tailwind/.husky"
+    "prepare": "husky install starters/solidjs-tailwind/.husky"
   },
   "license": "MIT",
   "devDependencies": {
@@ -32,7 +32,7 @@
     "@solidjs/router": "0.7.0",
     "@storybook/addon-actions": "6.5.16",
     "@storybook/addon-backgrounds": "6.5.16",
-    "@storybook/addon-docs": "6.5.16",
+    "@storybook/addon-docs": "^6.5.16",
     "@storybook/addon-essentials": "6.5.16",
     "@storybook/addon-links": "6.5.16",
     "@storybook/addon-measure": "6.5.16",
@@ -53,13 +53,13 @@
     "msw": "^0.49.2",
     "postcss": "8.4.21",
     "prettier": "2.8.4",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "solid-testing-library": "0.3.0",
     "storybook-addon-mock": "3.2.0",
     "tailwindcss": "3.2.6",
     "typescript": "4.9.5",
-    "vite": "3.2.5",
+    "vite": "4.1.4",
     "vite-plugin-solid": "2.5.0",
     "vitest": "0.28.5",
     "whatwg-fetch": "^3.6.2"


### PR DESCRIPTION
Due to some dependency issues, we are forced to open up some dependencies.

## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Documentation change
- [x] Bug fix

## Summary of change

<!-- Please include a brief summary of the changes made in this PR. You should also include any screenshots or videos when applicable -->

## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

- [ ] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [ ] This starter kit has been approved by the maintainers
- [x] Changes for this new starter kit are being pushed to an integration branch instead of main
- [ ] All dependencies are version locked
- [ ] This fix resolves #<!-- replace with issue number -->
- [x] I have verified the fix works and introduces no further errors
