### PR TITLE
fix: README.md image addresses for starter.dev website

### DIFF
--- a/starters/serverless-apollo-contentful/README.md
+++ b/starters/serverless-apollo-contentful/README.md
@@ -91,16 +91,20 @@ CONTENTFUL_ENVIRONMENT=master
 
 2. When that's done, go to **Settings** -> **API keys**
    Click on **Generate personal token** to get the `CONTENTFUL_CONTENT_MANAGEMENT_API_TOKEN` variable
-   ![API tokens](./screenshots/api-tokens.png)
+
+   ![API tokens](https://github.com/thisdot/starter.dev/blob/main/starters/serverless-apollo-contentful/screenshots/api-tokens.png?raw=true)
 
 3. Go to **Settings** -> **General settings** to get the `CONTENTFUL_SPACE_ID`
-   ![Space ID](./screenshots/space-id.png)  
+
+   ![Space ID](https://github.com/thisdot/starter.dev/raw/main/starters/serverless-apollo-contentful/screenshots/space-id.png)
+
    After you've gotten your API TOKEN and Space ID from contentful, modify the `.env` file and replace the `CONTENTFUL_CONTENT_MANAGEMENT_API_TOKEN` and `CONTENTFUL_SPACE_ID` variables.
 
 4. For demo purposes, this kit comes preconfigured with a `Technology` model. To use this, create the content model for
    it in Contentful. The model has `displayName`, `description` and `url` text fields. The `id` field gets provided by
    Contentful.
-   ![content models](./screenshots/content-models.png)
+
+   ![content models](https://github.com/thisdot/starter.dev/raw/main/starters/serverless-apollo-contentful/screenshots/content-models.png)
 
 The kit uses Redis for caching, so you would also need the credentials for the Redis server.
 

--- a/starters/serverless-apollo-contentful/README.md
+++ b/starters/serverless-apollo-contentful/README.md
@@ -92,7 +92,7 @@ CONTENTFUL_ENVIRONMENT=master
 2. When that's done, go to **Settings** -> **API keys**
    Click on **Generate personal token** to get the `CONTENTFUL_CONTENT_MANAGEMENT_API_TOKEN` variable
 
-   ![API tokens](https://github.com/thisdot/starter.dev/blob/main/starters/serverless-apollo-contentful/screenshots/api-tokens.png?raw=true)
+   ![API tokens](https://github.com/thisdot/starter.dev/raw/main/starters/serverless-apollo-contentful/screenshots/api-tokens.png)
 
 3. Go to **Settings** -> **General settings** to get the `CONTENTFUL_SPACE_ID`
 


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [x] Documentation change
- [ ] Bug fix

## Summary of change
Edit image address in README.md to make them show up in starter.dev

## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

- [x] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [x] This starter kit has been approved by the maintainers
- [ ] Changes for this new starter kit are being pushed to an integration branch instead of main
- [x] All dependencies are version locked
- [ ] This fix resolves #<!-- replace with issue number -->
- [x] I have verified the fix works and introduces no further errors
