### PR TITLE
feat: 1125 alphabetize the cli list of kits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ build
 # storybook
 documentation.json
 
+# IDEs and editors
+.idea/
+
 # misc
 .DS_Store
 *.pem

--- a/packages/create-starter/src/index.ts
+++ b/packages/create-starter/src/index.ts
@@ -27,7 +27,7 @@ export async function main() {
         starters = Object.entries(starterKitsJSON).map(([name, description]) => ({
           value: name as string,
           title: description as string,
-        }));
+        })).sort((a, b) => a.title.localeCompare(b.title));
       }
     } else {
       throw new Error();
@@ -39,10 +39,11 @@ export async function main() {
 
   const options = await prompts([
     {
-      type: 'select',
+      type: 'autocomplete',
       name: 'kit',
       message: 'Which starter kit would you like to use?',
       choices: starters,
+      suggest: (input, choices) => Promise.resolve(choices.filter(c => c.title.includes(input))),
     },
     {
       type: 'text',
@@ -95,7 +96,7 @@ export async function main() {
   }
 }
 
-async function initNodeProject(packageJsonPath: string, projectDestPath: string, options: prompts.Answers<"name" | "kit">) {
+async function initNodeProject(packageJsonPath: string, projectDestPath: string, options: prompts.Answers<'name' | 'kit'>) {
   const packageJSON = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'));
   packageJSON.name = options.name;
   packageJSON.version = '0.1.0';


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Documentation change
- [ ] Bug fix
- [x] New feature

## Summary of change

* sort kits alphabetically by title
* enable autocomplete for easier searching of kits

Additionally to sorting the list I also enabled autocomplete so the user can quickly search for the kit that they are interested in:

https://user-images.githubusercontent.com/22615575/221215705-85e9e024-7d92-46bf-be01-98e343b31288.mov




## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

- [x] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [x] This PR resolves #1125 
- [x] I have verified the fix works and introduces no further errors
