### PR TITLE
[express-apollo-prisma] Use Nodejs LTS version Codename instead of specific node version specified

### DIFF
--- a/starters/express-apollo-prisma/.nvmrc
+++ b/starters/express-apollo-prisma/.nvmrc
@@ -1,1 +1,1 @@
-v16.18.0
+lts/gallium


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Documentation change
- [ ] Bug fix

## Summary of change

Use Nodejs LTS version Codename instead of specific node version specified

## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

- [x] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [x] This starter kit has been approved by the maintainers
- [x] Changes for this new starter kit are being pushed to an integration branch instead of main
- [x] All dependencies are version locked
- [x] This fix resolves #867
- [x] I have verified the fix works and introduces no further errors
