### PR TITLE
fix: updating broken showcase links in readmes

### DIFF
--- a/starters/angular-ngrx-scss/README.md
+++ b/starters/angular-ngrx-scss/README.md
@@ -101,6 +101,6 @@ git clone https://github.com/thisdot/starter.dev.git
 
 ## Demo Implementation
 
-[Repository](https://github.com/thisdot/starter.dev-showcases/tree/main/angular-ngrx-scss)
+[Repository](https://github.com/thisdot/starter.dev-github-showcases/tree/main/angular-ngrx-scss)
 
 The demo application re-implements some of GitHub's pages and functionality. It uses the OAuth credentials in GitHub to authenticate users with their GitHub accounts and uses Angular services and NgRx to fetch data from the GitHub API. Check out the link above to learn more or check out the demo!

--- a/starters/cra-rxjs-styled-components/README.md
+++ b/starters/cra-rxjs-styled-components/README.md
@@ -121,6 +121,6 @@ The demo components included in the starter.kit are co-located with the tests an
 
 ## Demo Implementation
 
-[Repository](https://github.com/thisdot/starter.dev-showcases/tree/main/cra-rxjs-styled-components)
+[Repository](https://github.com/thisdot/starter.dev-github-showcases/tree/main/cra-rxjs-styled-components)
 
 The demo application re-implements some of GitHub's pages and functionality. It uses the OAuth credentials in GitHub to authenticate users with their GitHub accounts and uses RxJS to fetch data from the GitHub API. Check out the link above to learn more or check out the demo!

--- a/starters/next12-react-query-tailwind/README.md
+++ b/starters/next12-react-query-tailwind/README.md
@@ -89,6 +89,6 @@ Mock Service Worker makes it easy to write tests or stories for Components or fi
 
 ## Demo Implementation
 
-[Repository](https://github.com/thisdot/starter.dev-github-showcases/tree/main/next12-react-query-tailwind)
+[Repository](https://github.com/thisdot/starter.dev-github-showcases/tree/main/next-react-query-tailwind)
 
 The demo for this starter kit is a partial implementation of some GitHub functionality. It uses the NextAuth library to authenticate users with their GitHub accounts and uses the GitHub GraphQL API with codegen and React Query to fetch data from the GitHub API. Check out the link above to learn more or check out the demo!

--- a/starters/remix-gql-tailwind/README.md
+++ b/starters/remix-gql-tailwind/README.md
@@ -113,6 +113,6 @@ git clone https://github.com/thisdot/starter.dev.git
 
 ## Demo Implementation
 
-[Repository](https://github.com/thisdot/starter.dev-github-showcases/tree/main/remix)
+[Repository](https://github.com/thisdot/starter.dev-github-showcases/tree/main/remix-gql-tailwind)
 
 The demo application tries to implement some of GitHub's pages and functionality. It uses the OAuth credentials in GitHub to authenticate users with their GitHub accounts and uses graphql-request to fetch data from the GitHub GraphQL API. Check out the link above to learn more or check out the demo!


### PR DESCRIPTION
## Type of change

- [x] Documentation change
- [x] Bug fix

## Summary of change

There were several broken showcase links across the different starter kits.
I fixed all of the broken showcase links.

closes #1164 

## Checklist


- [x] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [x] I have verified the fix works and introduces no further errors
