### PR TITLE
feat: ESLint and Prettier configs

### DIFF
--- a/starters/next13-zustand-bulma/.eslintrc.json
+++ b/starters/next13-zustand-bulma/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": "next/core-web-vitals"
+  "root": true,
+  "extends": ["next/core-web-vitals"],
+  "plugins": [],
+  "rules": {}
 }

--- a/starters/next13-zustand-bulma/.prettierrc
+++ b/starters/next13-zustand-bulma/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "trailingComma": "es5",
+  "singleQuote": true
+}

--- a/starters/next13-zustand-bulma/LICENSE
+++ b/starters/next13-zustand-bulma/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 This Dot
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/starters/next13-zustand-bulma/next.config.js
+++ b/starters/next13-zustand-bulma/next.config.js
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  reactStrictMode: true,
   experimental: {
     appDir: true,
   },

--- a/starters/next13-zustand-bulma/package.json
+++ b/starters/next13-zustand-bulma/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "format": "yarn prettier --write ./src"
   },
   "dependencies": {
     "@next/font": "13.1.6",
@@ -19,5 +20,8 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "typescript": "4.9.5"
+  },
+  "devDependencies": {
+    "prettier": "^2.8.4"
   }
 }


### PR DESCRIPTION
## Changes

- Adds some placeholder options as a starting point for ESLint configs
- Adds Prettier and basic prettier config (same as other Next 12 kit)
- Adds missing LICENSE file
- Turns on reactStrictMode in NextJS config