### PR TITLE
fix(varied): update hello api endpoints to new working endpoint

### DIFF
--- a/starters/angular-ngrx-scss/src/app/fetch-example/fetch-example.service.ts
+++ b/starters/angular-ngrx-scss/src/app/fetch-example/fetch-example.service.ts
@@ -8,7 +8,7 @@ import { catchError, map, Observable } from 'rxjs';
 export class FetchExampleService {
   fetchMessage(greeting?: string): Observable<string> {
     return this.http
-      .get(`https://api.starter.dev/hello?greeting=${greeting}`, {
+      .get(`https://api.starter.dev/.netlify/functions/server/hello?greeting=${greeting}`, {
         responseType: 'text',
       })
       .pipe(

--- a/starters/cra-rxjs-styled-components/README.md
+++ b/starters/cra-rxjs-styled-components/README.md
@@ -37,7 +37,7 @@ This starter kit features Create React App, RxJS and styled-components.
 
 ### Example Components
 
-- React 'hello world' API endpoint `https://api.starter.dev/hello` with corresponding mock located in `src/components/RXJS-Example/RXJS-Example.test.tsx`.
+- React 'hello world' API endpoint `https://api.starter.dev/.netlify/functions/server/hello` with corresponding mock located in `src/components/RXJS-Example/RXJS-Example.test.tsx`.
 - Greeting component `src/components/RXJS-Example/RXJS-Example.test.tsx` that uses `rxjs/fetch` to fetch data from the example hello endpoint.
 - An example Counter component `src/components/Counter/Counter.tsx`
 - Both example components have co-located tests and stories.

--- a/starters/cra-rxjs-styled-components/src/components/FetchExample/FetchExample.stories.tsx
+++ b/starters/cra-rxjs-styled-components/src/components/FetchExample/FetchExample.stories.tsx
@@ -13,9 +13,12 @@ export const LoadingGreeting = Template.bind({});
 LoadingGreeting.parameters = {
   msw: {
     handlers: [
-      rest.get(`https://api.starter.dev/hello`, (req, res, ctx) => {
-        return res(ctx.text('Loading...'));
-      }),
+      rest.get(
+        `https://api.starter.dev/.netlify/functions/server/hello`,
+        (req, res, ctx) => {
+          return res(ctx.text('Loading...'));
+        }
+      ),
     ],
   },
 };
@@ -24,10 +27,18 @@ export const MessageWithGreeting = Template.bind({});
 MessageWithGreeting.parameters = {
   msw: {
     handlers: [
-      rest.get('https://api.starter.dev/hello', (req, res, ctx) => {
-        req.url.searchParams.set('greeting', 'cra-rxjs-styled-components kit!');
-        return res(ctx.text(`Hello, ${req.url.searchParams.get('greeting')}`));
-      }),
+      rest.get(
+        'https://api.starter.dev/.netlify/functions/server/hello',
+        (req, res, ctx) => {
+          req.url.searchParams.set(
+            'greeting',
+            'cra-rxjs-styled-components kit!'
+          );
+          return res(
+            ctx.text(`Hello, ${req.url.searchParams.get('greeting')}`)
+          );
+        }
+      ),
     ],
   },
 };

--- a/starters/cra-rxjs-styled-components/src/components/FetchExample/FetchExample.test.tsx
+++ b/starters/cra-rxjs-styled-components/src/components/FetchExample/FetchExample.test.tsx
@@ -9,7 +9,9 @@ test('returns a string result', () => {
   const onResponse = jest.fn();
   const onError = jest.fn();
 
-  return fetch('https://api.starter.dev/hello?greeting=from This Dot Labs!')
+  return fetch(
+    'https://api.starter.dev/.netlify/functions/server/hello?greeting=from This Dot Labs!'
+  )
     .then(onResponse)
     .catch(onError)
     .finally(() => {

--- a/starters/cra-rxjs-styled-components/src/components/FetchExample/FetchExample.tsx
+++ b/starters/cra-rxjs-styled-components/src/components/FetchExample/FetchExample.tsx
@@ -5,7 +5,7 @@ import {
   HomeLinkDiv,
   ReturnHomeLink,
   Message,
-  Loader
+  Loader,
 } from './FetchExample.styles';
 import { useState, useEffect } from 'react';
 import { fromFetch } from 'rxjs/fetch';
@@ -15,9 +15,11 @@ export const FetchExample = () => {
   const [loading, setLoading] = useState<boolean>(true);
   useEffect(() => {
     const subscription = fromFetch(
-      'https://api.starter.dev/hello?greeting=from This Dot Labs!'
+      'https://api.starter.dev/.netlify/functions/server/hello?greeting=from This Dot Labs!'
     ).subscribe((response) => response.text().then((data) => setMessage(data)));
-      setTimeout(() => {setLoading(false)  }, 2000);
+    setTimeout(() => {
+      setLoading(false);
+    }, 2000);
     return () => subscription.unsubscribe();
   }, []);
 

--- a/starters/next12-chakra-ui/__tests__/Greeting.test.tsx
+++ b/starters/next12-chakra-ui/__tests__/Greeting.test.tsx
@@ -24,7 +24,9 @@ it("returns a string result for the starter REST API", () => {
   const onResponse = jest.fn();
   const onError = jest.fn();
 
-  return fetch("https://api.starter.dev/hello?greeting=from This Dot Labs!")
+  return fetch(
+    "https://api.starter.dev/.netlify/functions/server/hello?greeting=from This Dot Labs!"
+  )
     .then(onResponse)
     .catch(onError)
     .finally(() => {

--- a/starters/next12-react-query-tailwind/src/components/Greeting/Greeting.data.tsx
+++ b/starters/next12-react-query-tailwind/src/components/Greeting/Greeting.data.tsx
@@ -10,7 +10,7 @@ export function Greeting() {
     ['hello'],
     async () => {
       const response = await fetch(
-        'https://api.starter.dev/hello?greeting=from This Dot Labs!'
+        'https://api.starter.dev/.netlify/functions/server/hello?greeting=from This Dot Labs!'
       );
       if (!response.ok) {
         const bodyText = await response.text();

--- a/starters/next12-react-query-tailwind/src/components/Greeting/Greeting.test.tsx
+++ b/starters/next12-react-query-tailwind/src/components/Greeting/Greeting.test.tsx
@@ -21,9 +21,12 @@ describe('Greeting', () => {
   describe('positive flow', () => {
     beforeAll(() => {
       server = setupServer(
-        rest.get('https://api.starter.dev/hello', (_, res, ctx) => {
-          return res(ctx.text(MOCK_MESSAGE_HELLO));
-        })
+        rest.get(
+          'https://api.starter.dev/.netlify/functions/server/hello',
+          (_, res, ctx) => {
+            return res(ctx.text(MOCK_MESSAGE_HELLO));
+          }
+        )
       );
       server.listen();
     });
@@ -62,8 +65,10 @@ describe('Greeting', () => {
 
     it('should show an error message if the API call response contains a message in the body.', async () => {
       server = setupServer(
-        rest.get('https://api.starter.dev/hello', (_, res, ctx) =>
-          res(ctx.status(400), ctx.json({ message: MOCK_MESSAGE_ERROR }))
+        rest.get(
+          'https://api.starter.dev/.netlify/functions/server/hello',
+          (_, res, ctx) =>
+            res(ctx.status(400), ctx.json({ message: MOCK_MESSAGE_ERROR }))
         )
       );
       server.listen();
@@ -81,8 +86,9 @@ describe('Greeting', () => {
 
     it('should show an error message if the API call response does not contain a message in the body.', async () => {
       server = setupServer(
-        rest.get('https://api.starter.dev/hello', (_, res, ctx) =>
-          res(ctx.status(404))
+        rest.get(
+          'https://api.starter.dev/.netlify/functions/server/hello',
+          (_, res, ctx) => res(ctx.status(404))
         )
       );
       server.listen();

--- a/starters/nuxt2-pinia-tailwind/components/FetchExample/FetchExample.test.ts
+++ b/starters/nuxt2-pinia-tailwind/components/FetchExample/FetchExample.test.ts
@@ -37,9 +37,12 @@ describe('<FetchExample />', () => {
   it('Should display error message', async () => {
     // Arrange
     mswServer.use(
-      rest.get('https://api.starter.dev/hello', (_, res, ctx) => {
-        return res(ctx.status(500));
-      })
+      rest.get(
+        'https://api.starter.dev/.netlify/functions/server/hello',
+        (_, res, ctx) => {
+          return res(ctx.status(500));
+        }
+      )
     );
 
     const componentOptions = {

--- a/starters/nuxt2-pinia-tailwind/components/FetchExample/FetchExample.vue
+++ b/starters/nuxt2-pinia-tailwind/components/FetchExample/FetchExample.vue
@@ -38,7 +38,7 @@ export default defineComponent({
     const message = useAsync(async () => {
       try {
         const response = await $axios.get<string>(
-          'https://api.starter.dev/hello?greeting=from This Dot Labs!'
+          'https://api.starter.dev/.netlify/functions/server/hello?greeting=from This Dot Labs!'
         );
         return response.data;
       } catch {

--- a/starters/nuxt2-pinia-tailwind/test/__mocks__/handlers/greeting.ts
+++ b/starters/nuxt2-pinia-tailwind/test/__mocks__/handlers/greeting.ts
@@ -1,7 +1,7 @@
 import { rest } from 'msw';
 
 export const greetingMock = rest.get(
-  'https://api.starter.dev/hello',
+  'https://api.starter.dev/.netlify/functions/server/hello',
   (req, res, ctx) => {
     const greeting = req.url.searchParams.get('greeting');
     return res(ctx.text(`Hello, ${greeting}`));


### PR DESCRIPTION
## Type of change

I noticed this `hello` API endpoint `https://api.starter.dev/hello` is used in many of the starter kits, but that endpoint is no longer operational.

I changed them to `https://api.starter.dev/.netlify/functions/server/hello` which **_is_** operational.

**Note:** Perhaps this is not the right fix, and we should instead get the `https://api.starter.dev/hello` endpoint working again?  If so feel free to comment and close this issue.

<!-- Add an x to the categories that apply -->

- [X] Bug fix

## Summary of change

<!-- Please include a brief summary of the changes made in this PR. You should also include any screenshots or videos when applicable -->

## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

- [X] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [X] I have verified the fix works and introduces no further errors
