### PR TITLE
fix(angular-ngrx-scss): fix deps

### DIFF
--- a/starters/angular-ngrx-scss/package.json
+++ b/starters/angular-ngrx-scss/package.json
@@ -40,7 +40,7 @@
     "@ngrx/store-devtools": "13.2.0",
     "rxjs": "7.8.0",
     "tslib": "2.5.0",
-    "zone.js": "0.12.0"
+    "zone.js": "0.11.4"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "13.3.10",


### PR DESCRIPTION
## Type of change

- [x] Bug fix

Fixes #1175 

## Summary of change
This PR drops the `zone.js` module to `0.11.4` so that `npm i` works without failing due to dependancy constraints

## Checklist

- [x] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [x] All dependencies are version locked
- [x] This fix resolves #1175 
- [x] I have verified the fix works and introduces no further errors
