### PR TITLE
feat(next13-zustand-bulma): add counter component

### DIFF
--- a/starters/next13-zustand-bulma/.storybook/preview.ts
+++ b/starters/next13-zustand-bulma/.storybook/preview.ts
@@ -1,4 +1,6 @@
 import type { Preview } from '@storybook/react';
+import { withFontDecorator } from './with-font-decorator';
+import '@/app/globals.scss';
 
 const preview: Preview = {
   parameters: {
@@ -14,5 +16,7 @@ const preview: Preview = {
     },
   },
 };
+
+export const decorators = [withFontDecorator];
 
 export default preview;

--- a/starters/next13-zustand-bulma/.storybook/with-font-decorator.tsx
+++ b/starters/next13-zustand-bulma/.storybook/with-font-decorator.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { Open_Sans } from 'next/font/google';
+
+const opensans = Open_Sans({ subsets: ['latin'], weight: 'variable' });
+
+export const withFontDecorator = (Story, context) => {
+  document.body.classList.add(opensans.className);
+  return <Story {...context} />;
+};

--- a/starters/next13-zustand-bulma/package.json
+++ b/starters/next13-zustand-bulma/package.json
@@ -16,6 +16,8 @@
     "bulma": "0.9.4",
     "clsx": "^1.2.1",
     "next": "13.2.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
     "sass": "^1.58.3",
     "typescript": "4.9.5",
     "zustand": "4.3.6"
@@ -32,20 +34,16 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
-    "@types/testing-library__jest-dom": "^5.14.5",
     "@types/node": "18.13.0",
     "@types/react": "18.0.27",
     "@types/react-dom": "18.0.10",
+    "@types/testing-library__jest-dom": "^5.14.5",
     "eslint": "8.35.0",
     "eslint-config-next": "13.2.4",
     "eslint-plugin-storybook": "0.6.11",
-    "jest": "^29.5.0",
-    "jest-environment-jsdom": "^29.5.0",
+    "jest": "29.5.0",
+    "jest-environment-jsdom": "29.5.0",
     "prettier": "2.8.4",
-    "storybook": "7.0.0-rc.3",
-    "next": "13.1.6",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "typescript": "4.9.5"
+    "storybook": "7.0.0-rc.3"
   }
 }

--- a/starters/next13-zustand-bulma/src/app/counter-example/page.tsx
+++ b/starters/next13-zustand-bulma/src/app/counter-example/page.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
 import Link from 'next/link';
+import { Counter } from '@/components/Counter';
 import styles from './page.module.scss';
 
 // Static metadata
@@ -19,7 +20,9 @@ export default function CounterPage() {
         >
           Increment, Decrement and Reset Button Example
         </h1>
-        <div className="block px-5">{/* Add Counter Component Here */}</div>
+        <div className="block">
+          <Counter />
+        </div>
         <div className="block is-size-5">
           <Link className="is-underlined" href="/">
             Return Home

--- a/starters/next13-zustand-bulma/src/app/globals.scss
+++ b/starters/next13-zustand-bulma/src/app/globals.scss
@@ -1,5 +1,5 @@
 // Add Bulma Variables + Overrides
-@import '@/base-styles';
+@import '../base-styles.scss';
 // Add Bulma Base Global Styles
 // these base styles cannot be imported into (S)CSS-Modules
 // so they must be imported as global styles here

--- a/starters/next13-zustand-bulma/src/components/Counter/Counter.stories.tsx
+++ b/starters/next13-zustand-bulma/src/components/Counter/Counter.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Counter } from './Counter';
+
+// More on how to set up stories at: https://storybook.js.org/docs/7.0/react/writing-stories/introduction
+const meta: Meta<typeof Counter> = {
+  title: 'Components/Counter',
+  component: Counter,
+  tags: ['autodocs'],
+};
+export default meta;
+
+type Story = StoryObj<typeof Counter>;
+
+// More on writing stories with args: https://storybook.js.org/docs/7.0/react/writing-stories/args
+export const Primary: Story = {
+  args: {},
+};

--- a/starters/next13-zustand-bulma/src/components/Counter/Counter.test.tsx
+++ b/starters/next13-zustand-bulma/src/components/Counter/Counter.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { Counter } from './Counter';
+
+describe('Counter', () => {
+  test('count should initially set 0', () => {
+    render(<Counter />);
+    const displayElement = screen.getByRole('status');
+    expect(displayElement).toHaveTextContent('Count: 0');
+  });
+
+  test('count should increase by 1 when clicking Increment button', async () => {
+    const user = userEvent.setup();
+    render(<Counter />);
+
+    const buttonIncrement = screen.getByText('Increment');
+    const displayElement = screen.getByRole('status');
+    expect(displayElement).toHaveTextContent('Count: 0');
+
+    await user.click(buttonIncrement);
+    expect(displayElement).toHaveTextContent('Count: 1');
+
+    await user.click(buttonIncrement);
+    expect(displayElement).toHaveTextContent('Count: 2');
+  });
+
+  test('should decrease by 1 when clicking button', async () => {
+    const user = userEvent.setup();
+    render(<Counter />);
+
+    const buttonDecrement = screen.getByText('Decrement');
+    const displayElement = screen.getByRole('status');
+    expect(displayElement).toHaveTextContent('Count: 0');
+
+    await user.click(buttonDecrement);
+    expect(displayElement).toHaveTextContent('Count: -1');
+
+    await user.click(buttonDecrement);
+    expect(displayElement).toHaveTextContent('Count: -2');
+  });
+
+  test('reset count to 0 when reset', async () => {
+    render(<Counter />);
+    const user = userEvent.setup();
+
+    const resetButton = screen.getByText('Reset');
+    const buttonIncrement = screen.getByText('Increment');
+    const displayElement = screen.getByRole('status');
+    expect(displayElement).toHaveTextContent('Count: 0');
+
+    await user.click(buttonIncrement);
+    await user.click(buttonIncrement);
+    await user.click(buttonIncrement);
+
+    expect(displayElement).toHaveTextContent('Count: 3');
+
+    await user.click(resetButton);
+    expect(displayElement).toHaveTextContent('Count: 0');
+  });
+});

--- a/starters/next13-zustand-bulma/src/components/Counter/Counter.tsx
+++ b/starters/next13-zustand-bulma/src/components/Counter/Counter.tsx
@@ -1,0 +1,41 @@
+'use client';
+import { useCountStore } from '@/stores/count';
+
+export function Counter() {
+  const { count, increment, decrement, reset } = useCountStore();
+
+  return (
+    <div className="level is-size-4">
+      <div className="level-item">
+        <output className="has-text-weight-bold m-2 p-2">Count: {count}</output>
+      </div>
+
+      <div className="level-item">
+        <button
+          className="button is-primary is-fullwidth is-justify-content-center has-centered-text has-text-weight-bold is-size-5 m-2"
+          onClick={increment}
+        >
+          Increment
+        </button>
+      </div>
+
+      <div className="level-item">
+        <button
+          className="button is-primary is-fullwidth is-justify-content-center has-centered-text has-text-weight-bold is-size-5 m-2"
+          onClick={decrement}
+        >
+          Decrement
+        </button>
+      </div>
+
+      <div className="level-item">
+        <button
+          className="button is-primary is-fullwidth is-justify-content-center has-centered-text has-text-weight-bold is-size-5 m-2"
+          onClick={reset}
+        >
+          Reset
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/starters/next13-zustand-bulma/src/components/Counter/index.ts
+++ b/starters/next13-zustand-bulma/src/components/Counter/index.ts
@@ -1,0 +1,1 @@
+export { Counter } from './Counter';

--- a/starters/next13-zustand-bulma/src/stores/count/count.test.ts
+++ b/starters/next13-zustand-bulma/src/stores/count/count.test.ts
@@ -17,6 +17,15 @@ describe('useCountStore', () => {
 
   test('decrease count when decrement is called', () => {
     const { result } = renderHook(() => useCountStore());
+    expect(result.current.count).toBe(0);
+
+    act(() => result.current.decrement());
+
+    expect(result.current.count).toBe(-1);
+  });
+
+  test('reset count to 0 when reset', () => {
+    const { result } = renderHook(() => useCountStore());
     act(() => result.current.increment());
     act(() => result.current.increment());
     act(() => result.current.increment());
@@ -25,14 +34,5 @@ describe('useCountStore', () => {
     act(() => result.current.reset());
 
     expect(result.current.count).toBe(0);
-  });
-
-  test('reset count to 0 when reset', () => {
-    const { result } = renderHook(() => useCountStore());
-    expect(result.current.count).toBe(0);
-
-    act(() => result.current.decrement());
-
-    expect(result.current.count).toBe(-1);
   });
 });


### PR DESCRIPTION
## Type of change

Add a Counter Component to the `next13-zustand-bulma` starter kit

<img width="500" alt="counter" src="https://user-images.githubusercontent.com/76821/224941271-af095016-827d-43ed-86ca-892b8dd46919.png">

This PR NOW relies on #1177 being merged first

## Summary of change
- added client counter component, test, and story
- put component in counter-example page

<!-- Please include a brief summary of the changes made in this PR. You should also include any screenshots or videos when applicable -->

## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

- [x] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [x] Changes for this new starter kit are being pushed to an integration branch instead of main
- [x] All dependencies are version locked
- [x] This fix resolves #994 
- [x] I have verified the fix works and introduces no further errors
