### PR TITLE
[serverless-framework-apollo-contentful] introduce pagination to getAll

### DIFF
--- a/starters/serverless-framework-apollo-contentful/src/models/Technology/getAll.spec.ts
+++ b/starters/serverless-framework-apollo-contentful/src/models/Technology/getAll.spec.ts
@@ -20,6 +20,7 @@ describe('getAll', () => {
 			expect(await getAll()).toHaveLength(2);
 		});
 	});
+
 	describe('when there are no technologies', () => {
 		beforeAll(() => {
 			(getEnvironment as MockedFn<typeof getEnvironment>).mockResolvedValueOnce({
@@ -32,6 +33,48 @@ describe('getAll', () => {
 
 		it('returns an empty array', async () => {
 			expect(await getAll()).toEqual([]);
+		});
+	});
+
+	describe('when passed pagination query properties', () => {
+		const getEntries = jest.fn();
+		beforeEach(() => {
+			(getEnvironment as MockedFn<typeof getEnvironment>).mockResolvedValueOnce({
+				getEntries: getEntries.mockClear().mockResolvedValue({ items: [] }),
+			} as unknown as Environment);
+		});
+		afterAll(() => {
+			(getEnvironment as MockedFn<typeof getEnvironment>).mockReset();
+		});
+
+		it('sends the right query to Contenful', async () => {
+			await getAll(4, 10);
+			expect(getEntries.mock.calls[0][0].limit).toBe(4);
+			expect(getEntries.mock.calls[0][0].skip).toBe(10);
+		});
+		it('uses sane defaults', async () => {
+			await getAll();
+			expect(getEntries.mock.calls[0][0].limit).toBe(100);
+			expect(getEntries.mock.calls[0][0].skip).toBe(0);
+		});
+	});
+
+	describe('when Contentful is misbehaving', () => {
+		beforeAll(async () => {
+			jest.spyOn(console, 'log').mockImplementation(() => undefined);
+			(getEnvironment as MockedFn<typeof getEnvironment>).mockResolvedValueOnce({
+				getEntries: async () => {
+					throw Error('MOCK_ERROR');
+				},
+			} as unknown as Environment);
+		});
+		afterAll(() => {
+			(console.log as jest.MockedFn<typeof console.log>).mockClear();
+		});
+
+		it('logs and rethrows the error', async () => {
+			await expect(getAll()).rejects.toThrow('MOCK_ERROR');
+			expect(console.log).toHaveBeenLastCalledWith('Error: MOCK_ERROR');
 		});
 	});
 });

--- a/starters/serverless-framework-apollo-contentful/src/models/Technology/getAll.ts
+++ b/starters/serverless-framework-apollo-contentful/src/models/Technology/getAll.ts
@@ -1,17 +1,20 @@
 import { getEnvironment } from '../../utils/contentful';
 import TechnologyModel from './TechnologyModel';
 
-export default async function getAll() {
+export default async function getAll(limit?: number | null, skip?: number | null) {
 	try {
 		const environment = await getEnvironment();
 		const entries = await environment.getEntries({
 			content_type: 'technology',
+			limit: limit || 100,
+			skip: skip || 0,
+			order: 'sys.createdAt',
 		});
 
 		return entries.items.map((entry) => new TechnologyModel(entry));
 	} catch (e) {
 		console.log('======= something went wrong fetch =======');
-		console.log(e);
+		console.log(String(e));
 		throw e;
 	}
 }

--- a/starters/serverless-framework-apollo-contentful/src/schema/technology/technology.resolvers.ts
+++ b/starters/serverless-framework-apollo-contentful/src/schema/technology/technology.resolvers.ts
@@ -7,8 +7,8 @@ export const technologyResolvers: Resolvers = {
 		technology: async (_parent, { id }) => {
 			return getById(id) as Promise<Technology>;
 		},
-		technologies: async () => {
-			return getAll() as Promise<Technology[]>;
+		technologies: async (_parent, { limit, offset }) => {
+			return getAll(limit, offset) as Promise<Technology[]>;
 		},
 	},
 	Mutation: {

--- a/starters/serverless-framework-apollo-contentful/src/schema/technology/technology.typedefs.ts
+++ b/starters/serverless-framework-apollo-contentful/src/schema/technology/technology.typedefs.ts
@@ -11,7 +11,7 @@ export const technologyTypeDefs = gql`
 	type Query {
 		"Technology: GET"
 		technology(id: ID!): Technology
-		technologies: [Technology]
+		technologies(offset: Int, limit: Int): [Technology!]
 	}
 
 	type Mutation {


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Documentation change
- [ ] Bug fix
- [x] Feature introduction

## Summary of change

Introduced "limit" and "offset" to the `technologies` query to offer pagination.

```
----------------------------|---------|----------|---------|---------|-------------------
File                        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------------------------|---------|----------|---------|---------|-------------------
All files                   |   96.52 |     82.5 |   93.33 |   97.67 |                   
 handlers                   |     100 |      100 |     100 |     100 |                   
  healthcheck.ts            |     100 |      100 |     100 |     100 |                   
  sqs-generate-job.ts       |     100 |      100 |     100 |     100 |                   
  sqs-handler.ts            |     100 |      100 |     100 |     100 |                   
 models/Technology          |    91.3 |    77.77 |   85.71 |   95.23 |                   
  TechnologyModel.ts        |   81.81 |    73.91 |      80 |   89.47 | 23,30             
  create.ts                 |     100 |      100 |     100 |     100 |                   
  getAll.ts                 |     100 |      100 |     100 |     100 |                   
  getById.ts                |     100 |      100 |     100 |     100 |                   
 schema/technology          |     100 |      100 |     100 |     100 |                   
  technology.resolvers.ts   |     100 |      100 |     100 |     100 |                   
 utils/contentful           |     100 |      100 |     100 |     100 |                   
  contentful-healthcheck.ts |     100 |      100 |     100 |     100 |                   
  contentful.ts             |     100 |      100 |     100 |     100 |                   
 utils/redis                |     100 |      100 |     100 |     100 |                   
  redis-healthcheck.ts      |     100 |      100 |     100 |     100 |                   
 utils/sqs                  |   97.61 |       80 |     100 |   97.29 |                   
  client.ts                 |    92.3 |       75 |     100 |   91.66 | 9                 
  getQueueUrl.ts            |     100 |      100 |     100 |     100 |                   
  is-offline.ts             |     100 |      100 |     100 |     100 |                   
  sendMessage.ts            |     100 |      100 |     100 |     100 |                   
----------------------------|---------|----------|---------|---------|-------------------

Test Suites: 16 passed, 16 total
Tests:       68 passed, 68 total
```

## Checklist

- [x] This fix resolves #1166
- [x] I have verified the fix works and introduces no further errors
