### PR TITLE
fix(next13-zustand-bulma): Bulma tag class on storybook Source component

### DIFF
--- a/starters/next13-zustand-bulma/.storybook/main.ts
+++ b/starters/next13-zustand-bulma/.storybook/main.ts
@@ -14,5 +14,27 @@ const config: StorybookConfig = {
   docs: {
     autodocs: 'tag',
   },
+  /* This is a little hack to fix the issue with Bulma's tag
+   component from the `tag` class being picked up by storybooks
+   `Source` component and messing with the styles.
+  */
+  previewHead: (head) => `
+  ${head}
+  <style>
+    pre.prismjs .tag {
+      align-items: initial;
+      background-color: initial;
+      border-radius: initial;
+      display: initial;
+      font-size: initial;
+      height: initial;
+      justify-content: initial;
+      line-height: initial;
+      padding-left: initial;
+      padding-right: initial;
+      white-space: initial;
+    }
+  </style>
+`,
 };
 export default config;


### PR DESCRIPTION
Storybook's `Source` component has a `class="tag"` and therefore Bulma's `tag` class is being picked up.

This PR adds a hacky little fix to ignore `.tag` if it's the ancestor of a `pre` element

## Type of change

- [x] Bug fix

## Summary of change

### Before
<img width="805" alt="Screenshot 2023-03-15 at 4 08 35 PM" src="https://user-images.githubusercontent.com/76821/225455108-3e759c15-3a14-40fb-9d70-bd11badac256.png">

### After
<img width="804" alt="Screenshot 2023-03-15 at 4 03 37 PM" src="https://user-images.githubusercontent.com/76821/225455113-4ad0d433-8a7f-4a64-adc8-1920d93b3438.png">


## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

- [x] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [x] Changes for this new starter kit are being pushed to an integration branch instead of main
- [x] All dependencies are version locked
- [x] I have verified the fix works and introduces no further errors
