### PR TITLE
Fix/1197 address demo comments

### DIFF
--- a/starter-kits.json
+++ b/starter-kits.json
@@ -11,7 +11,7 @@
   "nuxt2-pinia-tailwind": "Nuxt 2, Pinia and TailwindCSS",
   "qwik-graphql-tailwind": "Qwik, GraphQL, and TailwindCSS",
   "remix-gql-tailwind": "Remix, GQL and TailwindCSS",
-  "serverless-framework-apollo-contentful": "Serverless, Apollo Server, and Contentful CMS",
+  "serverless-framework-apollo-contentful": "Serverless Framework, Apollo Server, and Contentful CMS",
   "solidjs-tailwind": "SolidJS and TailwindCSS",
   "solidstart-tanstackquery-tailwind-modules": "Solid Start, TanStack Query and Tailwind CSS with CSS Modules",
   "svelte-kit-scss": "SvelteKit and SCSS",

--- a/starters/serverless-framework-apollo-contentful/.env.example
+++ b/starters/serverless-framework-apollo-contentful/.env.example
@@ -14,6 +14,6 @@ REDIS_CACHE_TTL_SECONDS=900
 SQS_PORT=9324
 
 # Allows you to run Serverless SQS offline
-AWS_ACCESS_KEY_ID="offline"
-AWS_SECRET_ACCESS_KEY="offline"
-AWS_SESSION_TOKEN="offline"
+AWS_ACCESS_KEY_ID=offline
+AWS_SECRET_ACCESS_KEY=offline
+AWS_SESSION_TOKEN=offline

--- a/starters/serverless-framework-apollo-contentful/README.md
+++ b/starters/serverless-framework-apollo-contentful/README.md
@@ -172,6 +172,12 @@ How to run migrations:
 
 [Learn more on migrations](https://www.contentful.com/developers/docs/tutorials/cli/scripting-migrations/)
 
+#### Demo content
+
+This kit comes with two demo migrations, the first one will add the base setup for our demo Technology model to Contentful. The second one changes the model so one can use the slug editor in Contentful's web interface.
+
+To test our migrations, run `01-*` before `02-*`. When developing your own application, remove the demo migrations and build your own. By prefixing the migration filenames with a number, one can ensure the migrations are ran in the correct order.
+
 ### Seeding
 
 To pre-populate the data within contentful we implement seeding scripts which are located in `scripts/seed`.

--- a/starters/serverless-framework-apollo-contentful/package.json
+++ b/starters/serverless-framework-apollo-contentful/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "serverless-framework-apollo-contentful",
 	"version": "1.0.0",
-	"description": "Serverless, Apollo Server, and Contentful CMS",
+	"description": "Serverless Framework, Apollo Server, and Contentful CMS",
 	"main": "src/handlers/graphql.ts",
 	"scripts": {
 		"dev": "sls offline start",

--- a/starters/serverless-framework-apollo-contentful/serverless.yml
+++ b/starters/serverless-framework-apollo-contentful/serverless.yml
@@ -47,6 +47,8 @@ functions:
           path: graphql
           method: get
           cors: true
+    environment:
+      SLS_STAGE: ${sls:stage}
   healthcheck:
     handler: src/handlers/healthcheck.handler
     events:

--- a/starters/serverless-framework-apollo-contentful/src/handlers/graphql.ts
+++ b/starters/serverless-framework-apollo-contentful/src/handlers/graphql.ts
@@ -29,13 +29,13 @@ export const apolloServer = new ApolloServer<MyContext>({
 			message = error.message;
 		}
 
-		if (process.env.NODE_ENV !== 'production') {
+		if (process.env.SLS_STAGE !== 'prod') {
 			return { ...formattedError, message };
 		}
 
 		return { message: message.message || message };
 	},
-	introspection: process.env.NODE_ENV !== 'production',
+	introspection: process.env.SLS_STAGE !== 'prod',
 });
 
 export const server = startServerAndCreateLambdaHandler<MyContext>(apolloServer, {

--- a/starters/serverless-framework-apollo-contentful/src/handlers/graphql.ts
+++ b/starters/serverless-framework-apollo-contentful/src/handlers/graphql.ts
@@ -29,8 +29,6 @@ export const apolloServer = new ApolloServer<MyContext>({
 			message = error.message;
 		}
 
-		console.log(process.env.NODE_ENV);
-
 		if (process.env.NODE_ENV !== 'production') {
 			return { ...formattedError, message };
 		}

--- a/starters/serverless-framework-apollo-contentful/src/handlers/sqs-generate-job.spec.ts
+++ b/starters/serverless-framework-apollo-contentful/src/handlers/sqs-generate-job.spec.ts
@@ -4,7 +4,9 @@ import { sendMessage } from '../utils/sqs';
 
 import { mockAWSLambdaHandlerContext } from '../utils/test/mocks';
 
-let MOCK_API_EVENT: APIGatewayProxyEvent;
+const MOCK_API_EVENT: APIGatewayProxyEvent = {
+	body: JSON.stringify({ message: 'Hello World!' }),
+} as unknown as APIGatewayProxyEvent;
 const MOCK_CONTEXT = mockAWSLambdaHandlerContext();
 const MOCK_CALLBACK = jest.fn();
 const MOCK_SEND_MESSAGE = sendMessage as jest.Mock;

--- a/starters/serverless-framework-apollo-contentful/src/models/Technology/TechnologyModel.spec.ts
+++ b/starters/serverless-framework-apollo-contentful/src/models/Technology/TechnologyModel.spec.ts
@@ -4,18 +4,35 @@ import { Entry } from 'contentful-management';
 jest.mock('../../utils/contentful');
 
 describe('TechnologyModel', () => {
+	const entry = {
+		publish: jest.fn(),
+		update: jest.fn(),
+		isDraft: () => false,
+		fields: {
+			displayName: { 'en-US': 'OLD_NAME' },
+			description: { 'en-US': 'MOCK_DESCRIPTION' },
+			url: { 'en-US': 'MOCK_URL' },
+		},
+	};
+
+	describe('fields', () => {
+		const model = new TechnologyModel({
+			...entry,
+			fields: { ...entry.fields },
+		} as unknown as Entry);
+
+		it('sets a description', () => {
+			model.description = 'MOCK_UPDATED_DESCRIPTION';
+			expect(model.description).toBe('MOCK_UPDATED_DESCRIPTION');
+		});
+		it('sets an url', () => {
+			model.url = 'MOCK_UPDATED_URL';
+			expect(model.url).toBe('MOCK_UPDATED_URL');
+		});
+	});
+
 	describe('.update', () => {
 		describe('when passed new display name', () => {
-			const entry = {
-				publish: jest.fn(),
-				update: jest.fn(),
-				isDraft: () => false,
-				fields: {
-					displayName: { 'en-US': 'OLD_NAME' },
-					description: { 'en-US': 'MOCK_DESCRIPTION' },
-					url: { 'en-US': 'MOCK_URL' },
-				},
-			};
 			entry.publish.mockImplementation(() => entry);
 			entry.update.mockImplementation(() => entry);
 			const technology = new TechnologyModel(entry as unknown as Entry);

--- a/starters/serverless-framework-apollo-contentful/src/schema/technology/technology.resolver.spec.ts
+++ b/starters/serverless-framework-apollo-contentful/src/schema/technology/technology.resolver.spec.ts
@@ -246,7 +246,7 @@ describe('technologyResolvers', () => {
 					});
 				});
 
-				describe('with a displayName', () => {
+				describe('with a displayName null', () => {
 					beforeAll(() => {
 						MOCK_GET_BY_ID.mockResolvedValue(MOCK_TECHNOLOGY_1);
 					});
@@ -258,7 +258,7 @@ describe('technologyResolvers', () => {
 						await expect(
 							RESOLVER_FN(
 								MOCK_PARENT_MUTATION,
-								{ id: 'MOCK_ID', fields: { displayName: 'MOCK_DISPLAY_NAME' } },
+								{ id: 'MOCK_ID', fields: { displayName: null } },
 								MOCK_CONTEXT,
 								MOCK_RESOLVE_INFO
 							)

--- a/starters/serverless-framework-apollo-contentful/src/schema/technology/technology.resolvers.ts
+++ b/starters/serverless-framework-apollo-contentful/src/schema/technology/technology.resolvers.ts
@@ -19,7 +19,7 @@ export const technologyResolvers: Resolvers = {
 		updateTechnology: async (_parent, { id, fields }) => {
 			const technology = await getById(id);
 			if (!fields) return technology;
-			if ('displayName' in fields && fields.displayName != null) {
+			if ('displayName' in fields && fields.displayName == null) {
 				throw new GraphQLError('Field "displayName" cannot be null');
 			}
 


### PR DESCRIPTION
## Type of change

- [ ] Documentation change
- [x] Bug fix

## Summary of change

- Change name to "Serverless Framework"
- Remove double quotes from .env file AWS credentials
- Update README to include the fact that both migrations exist
- Does the Contentful system not return pagination by their API? If pagination isn't available, note in README. If so, refactor to use it.
- Check and confirm that the mutations (update) are working correctly. There was a potential bug during the demo.
- In the graphql.ts file, SLS deploy use --stage flag for Serverless Framework
- Remove left-over console log from debugging
- Update tests so no errors are returned

## Checklist

- [x] This fix resolves #1197 
- [x] I have verified the fix works and introduces no further errors
- [x] Test coverage is over 80% 
