### PR TITLE
feat(#1008): add next13-zustand-bulma kit to cli

### DIFF
--- a/starter-kits.json
+++ b/starter-kits.json
@@ -7,6 +7,7 @@
   "express-typeorm-postgres": "Express.js, TypeOrm, and PostgreSQL",
   "next12-chakra-ui": "NextJS 12 and Chakra UI",
   "next12-react-query-tailwind": "NextJS 12, React Query, and TailwindCSS",
+  "next13-zustand-bulma": "NextJS 13, Zustand, and Bulma",
   "nuxt2-pinia-tailwind": "Nuxt 2, Pinia and TailwindCSS",
   "qwik-graphql-tailwind": "Qwik, GraphQL, and TailwindCSS",
   "remix-gql-tailwind": "Remix, GQL and TailwindCSS",
@@ -14,6 +15,5 @@
   "solidjs-tailwind": "SolidJS and TailwindCSS",
   "solidstart-tanstackquery-tailwind-modules": "Solid Start, TanStack Query and Tailwind CSS with CSS Modules",
   "svelte-kit-scss": "SvelteKit and SCSS",
-  "vue3-apollo-quasar": "Vue3, Apollo, and Quasar",
-  "next13-zustand-bulma": "NextJS 13, Zustand, and Bulma"
+  "vue3-apollo-quasar": "Vue3, Apollo, and Quasar"
 }

--- a/starter-kits.json
+++ b/starter-kits.json
@@ -14,5 +14,6 @@
   "solidjs-tailwind": "SolidJS and TailwindCSS",
   "solidstart-tanstackquery-tailwind-modules": "Solid Start, TanStack Query and Tailwind CSS with CSS Modules",
   "svelte-kit-scss": "SvelteKit and SCSS",
-  "vue3-apollo-quasar": "Vue3, Apollo, and Quasar"
+  "vue3-apollo-quasar": "Vue3, Apollo, and Quasar",
+  "next13-zustand-bulma": "NextJS 13, Zustand, and Bulma"
 }

--- a/starters/next13-zustand-bulma/package.json
+++ b/starters/next13-zustand-bulma/package.json
@@ -1,5 +1,6 @@
 {
   "name": "next13-zustand-bulma",
+  "description": "NextJS 13, Zustand, and Bulma",
   "version": "0.1.0",
   "private": true,
   "keywords": [

--- a/starters/next13-zustand-bulma/package.json
+++ b/starters/next13-zustand-bulma/package.json
@@ -1,6 +1,7 @@
 {
   "name": "next13-zustand-bulma",
   "description": "NextJS 13, Zustand, and Bulma",
+  "hasShowcase": false,
   "version": "0.1.0",
   "private": true,
   "keywords": [


### PR DESCRIPTION
## Type of change

- [ ] Documentation change
- [ ] Bug fix
- [x] Feature

## Summary of change

This adds `next13-zustand-bulma` to the starter CLI.

Code changes according to the guide in https://github.com/thisdot/starter.dev#adding-starter-kit-to-the-cli

To test this using this branch, I followed the steps:
- In `packages/create-starter/src/index.ts`, modify the script to consider this branch instead of `main`
  - [Line 11](https://github.com/thisdot/starter.dev/blob/main/packages/create-starter/src/index.ts#L11): change to `https://raw.githubusercontent.com/thisdot/starter.dev/feat/1008-add-kit-to-cli/starter-kits.json`
  - [Line 74](https://github.com/thisdot/starter.dev/blob/main/packages/create-starter/src/index.ts#L74): change to `thisdot/starter.dev/starters/${options.kit}#feat/1008-add-kit-to-cli`
- Build this package and run in a separate terminal (and different directory)

![Screen Shot 2023-03-22 at 11 07 02 AM](https://user-images.githubusercontent.com/104345646/227001169-43520a50-eddf-45ac-bd8f-324c1cb29774.png)

![Screen Shot 2023-03-22 at 11 10 36 AM](https://user-images.githubusercontent.com/104345646/227001314-6b77d5dc-d2fa-4920-80e2-4a5f4b73578e.png)

![Screen Shot 2023-03-22 at 11 11 30 AM](https://user-images.githubusercontent.com/104345646/227001448-f23f5939-bb92-4e9e-8c6a-5873cd891c3f.png)


## Checklist

- [x] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [x] Changes for this new starter kit are being pushed to an integration branch instead of main
- [x] All dependencies are version locked
- [x] This fix resolves #1008 
- [x] I have verified the fix works and introduces no further errors
