### PR TITLE
fix(next13-zustand-bulma): made generic withBodyClass decorator

### DIFF
--- a/starters/next13-zustand-bulma/.storybook/preview.ts
+++ b/starters/next13-zustand-bulma/.storybook/preview.ts
@@ -1,6 +1,9 @@
 import type { Preview } from '@storybook/react';
-import { withFontDecorator } from './with-font-decorator';
+import { Open_Sans } from 'next/font/google';
+import { withBodyClass } from './with-body-class';
 import '@/app/globals.scss';
+
+const opensans = Open_Sans({ subsets: ['latin'], weight: 'variable' });
 
 const preview: Preview = {
   parameters: {
@@ -14,9 +17,10 @@ const preview: Preview = {
         date: /Date$/,
       },
     },
+    bodyClass: opensans.className,
   },
 };
 
-export const decorators = [withFontDecorator];
+export const decorators = [withBodyClass];
 
 export default preview;

--- a/starters/next13-zustand-bulma/.storybook/with-body-class.tsx
+++ b/starters/next13-zustand-bulma/.storybook/with-body-class.tsx
@@ -1,0 +1,11 @@
+import { makeDecorator } from '@storybook/preview-api';
+import clsx from 'clsx';
+
+export const withBodyClass = makeDecorator({
+  name: 'withBodyClass',
+  parameterName: 'bodyClass',
+  wrapper: (storyFn, context, { parameters }) => {
+    document.body.classList.add(clsx(parameters));
+    return storyFn(context);
+  },
+});

--- a/starters/next13-zustand-bulma/.storybook/with-font-decorator.tsx
+++ b/starters/next13-zustand-bulma/.storybook/with-font-decorator.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { Open_Sans } from 'next/font/google';
-
-const opensans = Open_Sans({ subsets: ['latin'], weight: 'variable' });
-
-export const withFontDecorator = (Story, context) => {
-  document.body.classList.add(opensans.className);
-  return <Story {...context} />;
-};

--- a/starters/next13-zustand-bulma/README.md
+++ b/starters/next13-zustand-bulma/README.md
@@ -74,13 +74,13 @@ Overrides are done in the `base-styles.scss` file, which is imported in the `src
 
 You should import the `base-styles.scss` file in any component `*.module.scss` file, as per the example in `app/counter-example.page.tsx` to have access to the [Bulma variables](https://bulma.io/documentation/customize/variables/) for color and spacing in your component.
 
-Bulma is added to Storybook using the [`@storybok/addon-styling` package](https://storybook.js.org/addons/@storybook/addon-styling) which is the recommended way to add unsupported style frameworks to Storybook.
+Bulma is added to Storybook by importing the `@/app/globals.scss' file in the `preview.js` file.
 
-There is some code included to prevent Storybook's `Source` component from picking up styles from the Bulma `tag` component class. The explanation and solution can be found in [this pr](https://github.com/thisdot/starter.dev/pull/1186).
+_A little hack_: There is some code included to prevent Storybook's `Source` component from picking up styles from the Bulma `tag` component class. The explanation and solution can be found in [this pr](https://github.com/thisdot/starter.dev/pull/1186).
 
 ### Font Loading
 
-It takes advantage of the new [`next/font` package](https://beta.nextjs.org/docs/optimizing/fonts) for optimal font loading, and uses the [`@storybook/addon-styling` package](https://storybook.js.org/addons/@storybook/addon-styling), to provide the same font loading functionality to Storybook.
+It takes advantage of the new [`next/font` package](https://beta.nextjs.org/docs/optimizing/fonts) for optimal font loading, and uses a small `withBodyClass` decorator to add the font class to the body, mimicking the same behaviour done in the `app/layout.tsx` in the Storybook preview.
 
 ### Colocation in directories
 


### PR DESCRIPTION
## Type of change

- [x] Refactor and document

## Summary of change

Contrary to the name of the [issue this PR resolves](https://github.com/thisdot/starter.dev/issues/1193), I've learned the [@storybook/addon-styling](https://storybook.js.org/addons/@storybook/addon-styling) addon does not provide any functionality to help with the Bulma integration, it's more about adding themes to to the storybook preview pane and being able to adapt to the themes as they are changed.

So, instead this PR takes the approach of:

-  making the `with-font-decorator` decorator a generic `withBodyClass` decorator
- updating the documentation to reflect what we are in fact doing to make Bulma and `next/font` work with  storybook

## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

- [x] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [x] Changes for this new starter kit are being pushed to an integration branch instead of main
- [x] This fix resolves #1193 
- [x] I have verified the fix works and introduces no further errors
