### PR TITLE
ADD: Changes needed for VSCode debug launch settings

### DIFF
--- a/starters/next12-chakra-ui/.vscode/launch.json
+++ b/starters/next12-chakra-ui/.vscode/launch.json
@@ -1,0 +1,36 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Node: attach debugger",
+      "type": "node",
+      "request": "attach",
+      "skipFiles": ["<node_internals>/**"],
+      "port": 9229
+    },
+    {
+      "name": "Next.js: debug server-side",
+      "type": "node-terminal",
+      "request": "launch",
+      "sourceMaps": true,
+      "command": "npm run dev"
+    },
+    {
+      "name": "Next.js: debug client-side",
+      "type": "chrome",
+      "request": "launch",
+      "url": "http://localhost:3000"
+    },
+    {
+      "name": "Next.js: debug full stack",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "npm run dev",
+      "serverReadyAction": {
+        "pattern": "started server on .+, url: (https?://.+)",
+        "uriFormat": "%s",
+        "action": "debugWithChrome"
+      }
+    }
+  ]
+}

--- a/starters/next12-chakra-ui/package.json
+++ b/starters/next12-chakra-ui/package.json
@@ -9,7 +9,7 @@
     "chakra-ui"
   ],
   "scripts": {
-    "dev": "next dev",
+    "dev": "NODE_OPTIONS='--inspect' next dev",
     "test": "jest",
     "build": "next build",
     "start": "next start",

--- a/starters/next12-chakra-ui/tsconfig.json
+++ b/starters/next12-chakra-ui/tsconfig.json
@@ -7,6 +7,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
+    "sourceMap": true,
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "node",


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [X] Documentation change
- [ ] Bug fix
- [X] Other: Adding debug (launch) settings and sourcemaps for VSCode debugger and attach.

## Summary of change

Hello!  This PR adds a blend of Next 12.x's Launch.json configuration (for VSCode) and the necessary `sourceMaps` entry in the `tsconfig.json`.  Finally, we add the `--inspect` option to the `npm run dev` command for convenience. While `console.log` debugging works, JS breakpoint debugging is at least old enough to vote in the United States, so I'm hoping our fellow craftspeople use it. :)

**Note: Some users online (and me) found that the "attach" works reliably _after_ the first request to a Next route that has an active breakpoint set.  Like all of life's mysteries (this, though, likely related to how TypeScript's sourcemaps are produced and consumed just-in-time) reasons for this baffling behavior may elude us until some future major, minor, or patch release elucidates its cause, or replaces the cause of its misbehavior, and is thereby solved, fading quickly into our memories as a minor annoyance from a bygone era.**

## Checklist

- [X] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [X] I have verified the fix works and introduces no further errors
