### PR TITLE
fix: removing duplicate express icon

### DIFF
--- a/packages/website/src/config.tsx
+++ b/packages/website/src/config.tsx
@@ -366,12 +366,6 @@ export const TECHNOLOGIES = [
     Icon: (props) => <DenoIcon {...props} />,
   },
   {
-    key: 'express',
-    name: 'Express.js',
-    tags: ['Framework'],
-    Icon: (props) => <ExpressIcon {...props} />,
-  },
-  {
     key: 'typeorm',
     name: 'TypeORM',
     tags: ['Data Management'],


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Documentation change
- [x] Bug fix

## Summary of change

This PR is responsible for removing the duplicate express icon from the `config.tsx` file.

## Before
![Screenshot 2023-04-28 at 11 51 04 AM](https://user-images.githubusercontent.com/67210629/235259203-d6c5512a-82b2-4cef-b0e9-04b60dd31163.png)

## After

<img width="541" alt="Screenshot 2023-04-28 at 2 43 20 PM" src="https://user-images.githubusercontent.com/67210629/235259264-7c90a350-8ff9-4c3b-968e-c035b534bfa3.png">


## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

- [x] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [x] This starter kit has been approved by the maintainers
- [x] Changes for this new starter kit are being pushed to an integration branch instead of main
- [x] All dependencies are version locked
- [x] This fix resolves #1230 
- [x] I have verified the fix works and introduces no further errors
