### PR TITLE
fix: mh-deploy yml file

### DIFF
--- a/.github/workflows/mh-deploy.yml
+++ b/.github/workflows/mh-deploy.yml
@@ -6,8 +6,6 @@ on:
       - main
     paths:
       - 'packages/metrics-handler/**'
-  workflow_dispatch:
-
 
 jobs:
   deploy:
@@ -21,14 +19,14 @@ jobs:
         working-directory: 'packages/metrics-handler'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
-          cache-dependency-path: packages/metircs-handler/yarn.lock
+          cache-dependency-path: packages/metrics-handler/yarn.lock
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
## Type of change

- [ ] Documentation change
- [x] Bug fix

## Summary of change

This PR tries to solve the broken GH action in `mh-deploy.yml`.

`workflow_dispatch` cannot be empty.

See broken action in https://github.com/thisdot/starter.dev/actions/workflows/mh-deploy.yml