### PR TITLE
fix: let setup-node find the default cache path

### DIFF
--- a/.github/workflows/mh-deploy.yml
+++ b/.github/workflows/mh-deploy.yml
@@ -26,7 +26,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
-          cache-dependency-path: packages/metrics-handler/yarn.lock
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
## Type of change

- [ ] Documentation change
- [x] Bug fix

## Summary of change

Tracking the error message from `actions/setup-node`

```
Error: Some specified paths were not resolved, unable to cache dependencies.
```

https://github.com/actions/setup-node/blob/5b32c9063c6eb277dacbf3e916a8bc5d2617c5b7/src/main.ts#L64

We're setting up a cache path that doesn't exists, we should use the default path created by yarn itself.
