### PR TITLE
fix: env should be declared before the run

### DIFF
--- a/.github/workflows/mh-deploy.yml
+++ b/.github/workflows/mh-deploy.yml
@@ -34,14 +34,14 @@ jobs:
         run: npm i -g serverless@3
 
       - name: Configure credentials
-        run: |
-          serverless config credentials --provider aws --profile starterdev --key $AWS_ACCESS_KEY --secret $AWS_SECRET_KEY
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
+        run: |
+          serverless config credentials --provider aws --profile starterdev --key $AWS_ACCESS_KEY --secret $AWS_SECRET_KEY
 
       - name: Deploy
-        run: serverless deploy --stage production --region us-east-1
         env:
           GOOGLE_ANALYTICS_API_SECRET: ${{ secrets.GOOGLE_ANALYTICS_API_SECRET }}
           GOOGLE_ANALYTICS_MEASUREMENT_ID: ${{ secrets.GOOGLE_ANALYTICS_MEASUREMENT_ID }}
+        run: serverless deploy --stage production --region us-east-1

--- a/packages/metrics-handler/README.md
+++ b/packages/metrics-handler/README.md
@@ -15,4 +15,4 @@ In order to safely track generated events, we need a handler function that has a
 
 3. You can start up the handler function locally by running
 
-   `npm run dev`.
+   `npm run dev`


### PR DESCRIPTION
## Type of change

- [ ] Documentation change
- [x] Bug fix

## Summary of change

Error in GH action
![Screen Shot 2023-05-03 at 8 38 16 AM](https://user-images.githubusercontent.com/104345646/235966395-7add86c3-ab78-4c48-bd3b-e7cc8ef081a8.png)

`env` needs to be declared before `run` to ensure the variables are set.
