### PR TITLE
fix: use correct env vars

### DIFF
--- a/.github/workflows/mh-deploy.yml
+++ b/.github/workflows/mh-deploy.yml
@@ -38,7 +38,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
         run: |
-          serverless config credentials --provider aws --profile starterdev --key $AWS_ACCESS_KEY --secret $AWS_SECRET_KEY
+          serverless config credentials --provider aws --profile starterdev --key $AWS_ACCESS_KEY_ID --secret $AWS_SECRET_ACCESS_KEY
 
       - name: Deploy
         env:

--- a/packages/metrics-handler/README.md
+++ b/packages/metrics-handler/README.md
@@ -11,6 +11,7 @@ In order to safely track generated events, we need a handler function that has a
 2. Set up your .env file
 
    `cp .env.example .env`
+
    For valid environment variables, please reach out to the project coordinator.
 
 3. You can start up the handler function locally by running


### PR DESCRIPTION
## Type of change

- [ ] Documentation change
- [x] Bug fix

## Summary of change

The GH step is still broken and I didn't realize it was because of the typo on the env vars.
