### PR TITLE
fix: metrics-handler should use correct body props

### DIFF
--- a/packages/metrics-handler/index.js
+++ b/packages/metrics-handler/index.js
@@ -12,7 +12,7 @@ const GOOGLE_MEASUREMENT_PROTOCOL_ENDPOINT = (measurement_id, api_secret) =>
 module.exports.handler = async (event) => {
   const MEASUREMENT_ID = process.env.GOOGLE_ANALYTICS_MEASUREMENT_ID;
   const API_SECRET = process.env.GOOGLE_ANALYTICS_API_SECRET;
-  const selectedStarterKit = JSON.parse(event.body || 'null')?.starterKit;
+  const selectedStarterKit = JSON.parse(event.body || 'null')?.selectedKit;
 
   if (!selectedStarterKit) {
     console.log('No kit found');


### PR DESCRIPTION

## Type of change

- [ ] Documentation change
- [x] Bug fix

## Summary of change

ref: https://github.com/thisdot/starter.dev/blob/main/packages/create-starter/src/metrics.ts#L13

Adjusting the body props according to `create-starter/src/metrics.js` (using `selectedKit` instead of `starterKit`).

