### PR TITLE
Fix/vue3 xstate test issues

### DIFF
--- a/starters/vue3-xstate-css/.storybook/preview.js
+++ b/starters/vue3-xstate-css/.storybook/preview.js
@@ -1,9 +1,13 @@
+import { app } from '@storybook/vue3';
+
+app.provide('query', 'from Storybook!');
+
 export const parameters = {
-  actions: { argTypesRegex: "^on[A-Z].*" },
-  controls: {
-    matchers: {
-      color: /(background|color)$/i,
-      date: /Date$/,
-    },
-  },
-}
+	actions: { argTypesRegex: '^on[A-Z].*' },
+	controls: {
+		matchers: {
+			color: /(background|color)$/i,
+			date: /Date$/,
+		},
+	},
+};

--- a/starters/vue3-xstate-css/cypress/support/component.ts
+++ b/starters/vue3-xstate-css/cypress/support/component.ts
@@ -28,7 +28,7 @@ declare global {
 	}
 }
 
-Cypress.Commands.add('mount', (component, options) => {
+Cypress.Commands.add('mount', (component, options = {}) => {
 	options.global = options.global || {};
 	options.global.provide = options.global.provide || {};
 	return mount(component, options);

--- a/starters/vue3-xstate-css/src/stories/GreetView.stories.js
+++ b/starters/vue3-xstate-css/src/stories/GreetView.stories.js
@@ -17,4 +17,3 @@ const Template = (args) => ({
 });
 
 export const Default = Template.bind({});
-Default.args = { query: 'from Storybook!' };

--- a/starters/vue3-xstate-css/src/tests/GreetView.cy.ts
+++ b/starters/vue3-xstate-css/src/tests/GreetView.cy.ts
@@ -2,7 +2,7 @@ import GreetView from '../views/GreetView.vue';
 
 describe('<GreetView />', () => {
 	it('renders', () => {
-		cy.mount(GreetView, {});
+		cy.mount(GreetView);
 	});
 
 	it('should display a message with my greeting when I pass in a greeting', () => {


### PR DESCRIPTION
## Type of change

- [ ] Documentation change
- [x] Bug fix

## Summary of change

Noticed a few small things when testing out creation using the CLI.
- Counter tests were failing due to a change made to support the provide/inject options for the Greet tests. Provides a default value now so Counter tests work.
- Storybook was still using the prop for the Greet component, which now uses provide/inject. So removed the prop and updated the setup so it properly injects the value instead.

## Checklist

- [x] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [x] This starter kit has been approved by the maintainers
- [x] I have verified the fix works and introduces no further errors
