### PR TITLE
Fix: Vue3 XState cleanup issues

### DIFF
--- a/starter-kits.json
+++ b/starter-kits.json
@@ -17,5 +17,5 @@
   "solidstart-tanstackquery-tailwind-modules": "Solid Start, TanStack Query and Tailwind CSS with CSS Modules",
   "svelte-kit-scss": "SvelteKit and SCSS",
   "vue3-apollo-quasar": "Vue3, Apollo, and Quasar",
-  "vue3-xstate-css": "Vue 3, XState, and CSS"
+  "vue3-xstate-css": "Vue3, XState, and CSS"
 }

--- a/starters/vue3-xstate-css/.npmrc
+++ b/starters/vue3-xstate-css/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/starters/vue3-xstate-css/README.md
+++ b/starters/vue3-xstate-css/README.md
@@ -18,8 +18,6 @@ For more setup options, check out our [setup instructions in the wiki](https://g
 - [XState](https://xstate.js.org/)
 - CSS
 
-This kit is also set up to show the XState visualizer when run locally, to help you see what your state machines look like and how they work.
-
 ### Included Tooling
 
 - [Vite](https://vitejs.dev/) - build / bundle tool
@@ -50,6 +48,7 @@ Once you've generated your new starter kit following the instructions above:
 ## Available commands
 
 - `npm run dev` starts the local development server
+- `npm run dev:debug` starts the local dev server and launches the xstate visualizer
 
 - `npm run build-only` handles compiling and minifying your files
 - `npm run type-check` type checks your files
@@ -83,17 +82,9 @@ The main folder you'll interact with is the `src` folder. This is split into a f
 
 ### Using XState
 
-#### The visualizer
-
-To get the visualizer working locally, we're using the `@xstate/inspect` package and importing it within the `main.ts` file. Then within our components, when we want to be able to visualize our state machine we pass the `devtools: true` option when we call `useMachine`. The visualizer allows us to see what a particular state machine looks like by letting us manually trigger different states and actions. You can even directly change the machine within the visualizer to test out changes you might want to make. Just make sure that if you want to keep those changes you copy it back into your machine file!
-
 #### State vs Context
 
 You'll notice that within both of our example machines, we're using a `context` object. You can read more specifics about how this works [in the XState documentation on context](https://xstate.js.org/docs/guides/context.html#initial-context), but in general the context stores data that might be quantitative in nature (like numbers, strings, or objects).
-
-In [the introduction to state machines documentation](https://xstate.js.org/docs/guides/introduction-to-state-machines-and-statecharts/#states), they give the example of a dog's "state" as being asleep or awake. A dog can't be both asleep and awake at the same time - it has to be one or the other. The same is true of our states. You'll see this best in the `greetMachine.ts` file. We're either loading our data, we received our complete data, or we received our error data. The machine can only be in one of these three states.
-
-We use the context to store information that might change as we go through different states. In our greetMachine, we use the context to store the query we're sending, the message we get back, and any potential error text we get back. Since the items here are arbitrary and can change as our machine moves through it's states, we store these in the context object.
 
 #### TS Support in Machines
 
@@ -103,91 +94,21 @@ XState offers us a `schema` option in our machines to allow us to type our state
 
 The `createMachine` call that we use to build machines accepts two objects.
 
-The first object is always present, and specifies the name of our machine, it's initial state, any local context it needs, and the states our machine can be in.
-
-```js
-import { createMachine } from 'xstate';
-
-const lightMachine = createMachine({
-	// Machine identifier
-	id: 'light',
-
-	// Initial state
-	initial: 'green',
-
-	// Local context for entire machine
-	context: {
-		elapsed: 0,
-		direction: 'east',
-	},
-
-	// State definitions
-	states: {
-		green: {
-			/* ... */
-		},
-		yellow: {
-			/* ... */
-		},
-		red: {
-			/* ... */
-		},
-	},
-});
-```
-
-Eventually our states will need to define actions, services, or guards. These can be written directly within the state itself, or they can be passed to the optional second object in the `createMachine` function, and then referenced in the state by their name.
-
-```js
-const lightMachine = createMachine(
-	{
-		id: 'light',
-		initial: 'green',
-		states: {
-			green: {
-				// action referenced via string
-				entry: 'alertGreen',
-			},
-		},
-	},
-	{
-		actions: {
-			// action implementation
-			alertGreen: (context, event) => {
-				alert('Green!');
-			},
-		},
-		guards: {
-			/* ... */
-		},
-		services: {
-			/* ... */
-		},
-	}
-);
-```
+The first object is always present, and specifies the name of our machine, it's initial state, any local context it needs, and the states our machine can be in. Eventually our states will need to define actions, services, or guards. These can be written directly within the state itself, or they can be passed to the optional second object in the `createMachine` function, and then referenced in the state by their name.
 
 You'll see both options in this kit - the `counterMachine` has it's actions defined separately, and the `greetMachine` has the actions inline in the state but the service defined separately. Either option is valid. You might start with your actions inlined to ensure they work, and then separate them out to make them easier to read and debug.
 
-#### Predictable Action Arguments Flag
-
-You'll see the option `predictableActionArguments: true` within our machines. This is recommended per the docs, and will be a default option in the next version. This flag means that XState will always call an action with the direct event that triggered it.
-
 ### Vue 3 Benefits
 
-Since we're using Vue 3, we're able to make use of the composition API. This means we can use the `setup` option in our component's script tags, which lets us define our variables and functions in a style that looks a bit more like standard JS. With this method, we don't have to have an object that defines all of the values our component can use - it allows us to use standard variables and functions which can be used directly in our templates.
-
-Another benefit of using Vue 3 is getting to work with the new provide and inject functions. These allow us to set up our own dependency system, so instead of having to deal with prop drilling and passing values along components that don't need them, we can provide that value in a parent component and then inject it into the component that needs it, bypassing all the others.
+A key benefit of using Vue 3 is getting to work with the new `provide` and `inject` functions. These allow us to set up our own dependency system, so instead of having to deal with prop drilling and passing values along components that don't need them, we can provide that value in a parent component and then inject it into the component that needs it, bypassing all the others.
 
 You can see an example of this with the `GreetView` component. We needed a way to provide an initial query value, but didn't want to have to set up a prop within the router or drill it down through the home component. So we set up the `provide` function in the `main.ts` file, which makes it globally available in our app to any component that needs it. The `provide` function takes two arguments, a key and a value. Then, our `GreetView` component can inject that value and make use of it. We're also able to set a default value in case the provided key doesn't have a value.
 
 ### Cypress Testing
 
-The only specific setup thing we needed to do to enable component testing was to add the `mount` command to Cypress. They have packages available for multiple common frameworks which will provide the functionality for you - all we have to do is go into our `cypress/support/component.ts` file, import the `mount` function, and then tell Cypress to add that command. This lets us mount our individual components so we can then run our Cypress tests directly on that component.
+The only specific setup thing we needed to do to enable component testing was to add the `mount` command to Cypress. They have packages available for multiple common frameworks which will provide the functionality for you - all we have to do is go into our `cypress/support/component.ts` file, import the `mount` function, and then tell Cypress to add that command.
 
 To enable our tests to also be able to access our provided value in the `GreetView` component, we've customized the provided `mount` function so that we provide an initial value. Then, for each test that needs to mount the component, we can either provide it with nothing (thus allowing our default value to be tested) or give it a custom message just for our tests to ensure everything works as expected.
-
-That `cypress/support/component.ts` file is also where you'll import any global styles your components might need.
 
 ## Deployment
 

--- a/starters/vue3-xstate-css/README.md
+++ b/starters/vue3-xstate-css/README.md
@@ -48,7 +48,7 @@ Once you've generated your new starter kit following the instructions above:
 ## Available commands
 
 - `npm run dev` starts the local development server
-- `npm run dev:debug` starts the local dev server and launches the xstate visualizer
+- `npm run dev:debug` starts the local dev server and launches the XState visualizer
 
 - `npm run build-only` handles compiling and minifying your files
 - `npm run type-check` type checks your files

--- a/starters/vue3-xstate-css/package.json
+++ b/starters/vue3-xstate-css/package.json
@@ -8,9 +8,12 @@
 		"css"
 	],
 	"hasShowcase": false,
+	"engines": {
+		"node": "16.18"
+	},
 	"scripts": {
 		"dev": "vite",
-    "dev:debug": "VITE_DEV_MODE='debug' vite",
+		"dev:debug": "VITE_DEV_MODE='debug' vite",
 		"build": "run-p type-check build-only",
 		"preview": "vite preview",
 		"test:unit": "cypress run --component",

--- a/starters/vue3-xstate-css/package.json
+++ b/starters/vue3-xstate-css/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "vue3-xstate-css",
 	"version": "0.0.0",
-	"description": "Vue 3, XState, and CSS",
+	"description": "Vue3, XState, and CSS",
 	"keywords": [
 		"vue",
 		"xstate",
@@ -10,6 +10,7 @@
 	"hasShowcase": false,
 	"scripts": {
 		"dev": "vite",
+    "dev:debug": "VITE_DEV_MODE='debug' vite",
 		"build": "run-p type-check build-only",
 		"preview": "vite preview",
 		"test:unit": "cypress run --component",

--- a/starters/vue3-xstate-css/src/components/ButtonComponent.vue
+++ b/starters/vue3-xstate-css/src/components/ButtonComponent.vue
@@ -16,6 +16,7 @@ button {
 	padding: 0.5em 0.25em;
 	border-radius: 4px;
 	border-color: var(--lightBlue);
+	cursor: pointer;
 }
 
 @media screen and (max-width: 768px) {

--- a/starters/vue3-xstate-css/src/main.ts
+++ b/starters/vue3-xstate-css/src/main.ts
@@ -5,9 +5,12 @@ import { inspect } from '@xstate/inspect';
 
 import './assets/main.css';
 
-inspect({
-	iframe: false,
-});
+const devMode = import.meta.env.VITE_DEV_MODE;
+if (devMode === 'debug') {
+	inspect({
+		iframe: false,
+	});
+}
 
 const app = createApp(App);
 


### PR DESCRIPTION
## Type of change

- [x] Documentation change
- [x] Bug fix

## Summary of change

A few small cleanup tasks from an overall kit review recently.
- Simplify the README to focus more on specific decisions made
- Create a separate `dev:debug` script to run the XState visualizer in
- Set the cursor to be a pointer on the button components
- Adjusted the spelling of the kit name in the package.json description to match the other Vue3 kit
- Enforced the specific node version, to avoid conflict issues between Storybook / Node / Webpack / SSL

## Checklist

- [ ] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [ ] This starter kit has been approved by the maintainers
- [ ] I have verified the fix works and introduces no further errors
