### PR TITLE
fix: incorrect showcase link for expo kit

### DIFF
--- a/starter-kits.json
+++ b/starter-kits.json
@@ -3,7 +3,7 @@
   "angular-ngrx-scss": "Angular, NgRx, and SCSS",
   "cra-rxjs-styled-components": "Create React App, RxJS and Styled Components",
   "deno-oak-denodb": "Deno, Oak, and DenoDB",
-  "expo-zustand-styled-component": "Expo, Zustand, and Styled Components",
+  "expo-zustand-styled-components": "Expo, Zustand, and Styled Components",
   "express-apollo-prisma": "Express.js, Apollo Server, and Prisma",
   "express-typeorm-postgres": "Express.js, TypeOrm, and PostgreSQL",
   "next12-chakra-ui": "NextJS 12 and Chakra UI",

--- a/starters/expo-zustand-styled-components/app.json
+++ b/starters/expo-zustand-styled-components/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
-    "name": "expo-zustand-styled-component",
-    "slug": "expo-zustand-styled-component",
+    "name": "expo-zustand-styled-components",
+    "slug": "expo-zustand-styled-components",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
@@ -14,9 +14,7 @@
     "updates": {
       "fallbackToCacheTimeout": 0
     },
-    "assetBundlePatterns": [
-      "**/*"
-    ],
+    "assetBundlePatterns": ["**/*"],
     "ios": {
       "supportsTablet": true
     },

--- a/starters/expo-zustand-styled-components/package.json
+++ b/starters/expo-zustand-styled-components/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "expo-zustand-styled-component",
-  "description": "Expo (React-Native), Zustand, Styled-Components",
+  "name": "expo-zustand-styled-components",
+  "description": "Expo, Zustand, and Styled Components",
   "version": "1.0.0",
   "main": "node_modules/expo/AppEntry.js",
   "keywords": [
@@ -8,7 +8,6 @@
     "zustand",
     "styled-components"
   ],
-  "description": "Expo, Zustand, and Styled Components",
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Documentation change
- [x] Bug fix

## Summary of change

This PR fixes all incorrect kit name of `expo-zustand-styled-component` to the correct `expo-zustand-styled-components`. Now the showcase link directs users to the correct page.

<img width="973" alt="Screenshot 2023-06-12 at 8 55 39 AM" src="https://github.com/thisdot/starter.dev/assets/67210629/b48a10d7-6ec3-4dac-bc18-ff13d11c9cf3">



## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

- [x] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [x] This fix resolves #1268 
- [x] I have verified the fix works and introduces no further errors
