### PR TITLE
fix: allow CLI kit searches to be more flexible

### DIFF
--- a/packages/create-starter/src/index.ts
+++ b/packages/create-starter/src/index.ts
@@ -25,10 +25,12 @@ export async function main() {
     if (res.ok) {
       const starterKitsJSON = await res.json();
       if (typeof starterKitsJSON === 'object' && starterKitsJSON !== null) {
-        starters = Object.entries(starterKitsJSON).map(([name, description]) => ({
-          value: name as string,
-          title: description as string,
-        })).sort((a, b) => a.title.localeCompare(b.title));
+        starters = Object.entries(starterKitsJSON)
+          .map(([name, description]) => ({
+            value: name as string,
+            title: description as string,
+          }))
+          .sort((a, b) => a.title.localeCompare(b.title));
       }
     } else {
       throw new Error();
@@ -44,7 +46,7 @@ export async function main() {
       name: 'kit',
       message: 'Which starter kit would you like to use?',
       choices: starters,
-      suggest: (input, choices) => Promise.resolve(choices.filter(c => c.title.includes(input))),
+      suggest: (input, choices) => Promise.resolve(choices.filter((c) => c.title.toLowerCase().includes(input.toLowerCase()))),
     },
     {
       type: 'text',
@@ -57,17 +59,13 @@ export async function main() {
     process.exit(1);
   }
 
-  const [createSelectedKitResult] = await Promise.allSettled([
-    createStarter(options),
-    trackSelectedKit(options.kit)
-  ])
+  const [createSelectedKitResult] = await Promise.allSettled([createStarter(options), trackSelectedKit(options.kit)]);
 
   if (createSelectedKitResult.status === 'rejected') {
     const err = createSelectedKitResult.reason;
     console.error(red(err instanceof Error ? err.message : `Creating starter kit failed`));
     process.exit(1);
   }
-
 }
 
 async function createStarter(options: prompts.Answers<'name' | 'kit'>): Promise<void> {
@@ -109,7 +107,7 @@ async function createStarter(options: prompts.Answers<'name' | 'kit'>): Promise<
       console.log(` ${bold(cyan('npm install'))} (or pnpm install, yarn, etc)`);
     }
   } catch (err: unknown) {
-    throw new Error('Failed to initialize the starter kit. This probably means that you provided an invalid kit name.')
+    throw new Error('Failed to initialize the starter kit. This probably means that you provided an invalid kit name.');
   }
 }
 
@@ -130,5 +128,3 @@ async function initNodeProject(packageJsonPath: string, projectDestPath: string,
     console.info(gray(`> ${bold('Note:')} Failed to update package.json. You may need to do this manually.`));
   }
 }
-
-


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Documentation change
- [x] Bug fix

## Summary of change

This PR removes the strict nature for CLI kit searches and fixes a couple of small formatting inconsistencies. 

## Before
<img width="393" alt="Screen Shot 2023-06-13 at 10 44 33 AM" src="https://github.com/thisdot/starter.dev/assets/67210629/34719d1a-0168-4de7-a10b-b1ebd08adddb">

## After

<img width="834" alt="Screen Shot 2023-06-13 at 10 45 03 AM" src="https://github.com/thisdot/starter.dev/assets/67210629/97ec16c8-29db-4931-bde0-01e630e05088">


## Checklist


- [x] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [x] This fix resolves #1273 
- [x] I have verified the fix works and introduces no further errors
