### PR TITLE
Audit READMES - remove table of contents, correct demo links and hasShowcase values

### DIFF
--- a/starters/angular-apollo-tailwind/README.md
+++ b/starters/angular-apollo-tailwind/README.md
@@ -2,18 +2,6 @@
 
 This starter kit features **Angular 13**, **Apollo** and **Tailwind CSS**.
 
-## Table of Contents
-
-- [Overview](#overview)
-  - [Tech Stack](#tech-stack)
-  - [Included Tooling](#included-tooling)
-  - [Example Components](#example-components)
-- [Installation](#installation)
-  - [CLI](#cli-recommended)
-  - [Manual](#manual)
-- [Commands](#commands)
-- [Demo Implementation](#demo-implementation)
-
 ## Overview
 
 ### Tech Stack
@@ -89,4 +77,4 @@ git clone https://github.com/thisdot/starter.dev.git
 
 [Repository](https://github.com/thisdot/starter.dev-github-showcases/tree/main/angular-apollo-tailwind)
 
-[Live Application](http://angular-apollo-tailwind.starter.dev/)
+[Live Application](https://angular-apollo-tailwind.starter.dev/)

--- a/starters/angular-ngrx-scss/README.md
+++ b/starters/angular-ngrx-scss/README.md
@@ -2,19 +2,6 @@
 
 This starter kit features Angular 13, NgRx and SCSS.
 
-## Table of Contents
-
-- [Overview](#overview)
-  - [Tech Stack](#tech-stack)
-  - [Included Tooling](#included-tooling)
-  - [Architectural Decisions](#architectural-decisions)
-  - [Example Components](#example-components)
-- [Installation](#installation)
-  - [CLI](#cli-recommended)
-  - [Manual](#manual)
-- [Commands](#commands)
-- [Demo Implementation](#demo-implementation)
-
 ## Overview
 
 ### Tech Stack

--- a/starters/cra-rxjs-styled-components/README.md
+++ b/starters/cra-rxjs-styled-components/README.md
@@ -2,22 +2,6 @@
 
 This starter kit features Create React App, RxJS and styled-components.
 
-## Table of Contents
-
-- [cra-rxjs-styled-components starter kit](#cra-rxjs-styled-components-starter-kit)
-  - [Table of Contents](#table-of-contents)
-  - [Overview](#overview)
-    - [Tech Stack](#tech-stack)
-    - [Included Tooling](#included-tooling)
-    - [Example Components](#example-components)
-  - [Installation](#installation)
-    - [CLI (Recommended)](#cli-recommended)
-    - [Manual](#manual)
-  - [Commands](#commands)
-  - [Kit Organization / Architecture](#kit-organization--architecture)
-    - [Example directory](#example-directory)
-  - [Demo Implementation](#demo-implementation)
-
 ## Overview
 
 ### Tech Stack
@@ -122,5 +106,7 @@ The demo components included in the starter.kit are co-located with the tests an
 ## Demo Implementation
 
 [Repository](https://github.com/thisdot/starter.dev-github-showcases/tree/main/cra-rxjs-styled-components)
+
+[Live Application](https://cra-rxjs-styled-components.starter.dev/)
 
 The demo application re-implements some of GitHub's pages and functionality. It uses the OAuth credentials in GitHub to authenticate users with their GitHub accounts and uses RxJS to fetch data from the GitHub API. Check out the link above to learn more or check out the demo!

--- a/starters/deno-oak-denodb/README.md
+++ b/starters/deno-oak-denodb/README.md
@@ -1,29 +1,5 @@
 # deno-oak-denodb starter kit
 
-## Table of contents
-
-* [Overview](#overview)
-* [Installation](#installation)
-	+ [CLI (Recommended)](#cli-recommended)
-	+ [Manual](#manual)
-	+ [Database setup](#database-setup)
-	+ [Seeding](#seeding)
-* [Available commands](#available-commands)
-	+ [Tasks](#tasks)
-	+ [Formatting and linting](#formatting-and-linting)
-	+ [Testing](#testing)
-	+ [Keeping integrity through lock file](#keeping-integrity-through-lock-file)
-	+ [Generating documentation](#generating-documentation)
-	+ [Generating TypeScript files from GraphQL schema](#generating-typescript-files-from-graphql-schema)
-* [Using the GraphQL API](#using-the-graphql-api)
-* [CORS configuration](#cors-configuration)
-* [Kit organization / architecture](#kit-organization--architecture)
-	+ [Default API routes](#default-api-routes)
-	+ [Expanding further](#expanding-further)
-		- [Authentication](#authentication)
-		- [Templating](#templating)
-* [Deployment](#deployment)
-
 ## Overview
 
 This starter kit can be used for scaffolding an all-Deno based backend. It uses the following technologies:

--- a/starters/expo-zustand-styled-components/README.md
+++ b/starters/expo-zustand-styled-components/README.md
@@ -2,19 +2,6 @@
 
 This starter kit features **Expo**, combined with **Zustand**, and **Styled-components**
 
-- [expo-zustand-styled-components starter kit](#expo-zustand-styled-components-starter-kit)
-  - [Table of Contents](#table-of-contents)
-  - [Overview](#overview)
-    - [Tech Stack](#tech-stack)
-    - [Included Tooling](#included-tooling)
-    - [Example Components](#example-components)
-  - [Installation](#installation)
-    - [CLI (Recommended)](#cli-recommended)
-    - [Manual](#manual)
-  - [Commands](#commands)
-  - [Kit Organization / Architecture](#kit-organization--architecture)
-  - [Demo Implementation](#demo-implementation)
-
 ## Overview
 
 ### Tech Stack
@@ -103,5 +90,7 @@ The demo components included in the starter.kit are co-located with the tests. I
 ## Demo Implementation
 
 [Repository](https://github.com/thisdot/starter.dev-github-showcases/tree/main/expo-zustand-styled-components)
+
+[Live Application](https://expo-zustand-styled-components.starter.dev/)
 
 The demo application re-implements some of GitHub's pages and functionality. It uses the OAuth credentials in GitHub to authenticate users with their GitHub accounts and uses RxJS to fetch data from the GitHub API. Check out the link above to learn more or check out the demo!

--- a/starters/expo-zustand-styled-components/package.json
+++ b/starters/expo-zustand-styled-components/package.json
@@ -8,6 +8,7 @@
     "zustand",
     "styled-components"
   ],
+  "hasShowcase": true,
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",

--- a/starters/express-apollo-prisma/README.md
+++ b/starters/express-apollo-prisma/README.md
@@ -2,37 +2,6 @@
 
 This starter kit features Express, Apollo Server and Prisma.
 
-## Table of Contents
-
-- [express-apollo-prisma starter kit](#express-apollo-prisma-starter-kit)
-  - [Table of Contents](#table-of-contents)
-  - [Overview](#overview)
-    - [Tech Stack](#tech-stack)
-    - [Included Tooling](#included-tooling)
-  - [Installation](#installation)
-    - [CLI (Recommended)](#cli-recommended)
-    - [Manual](#manual)
-  - [Built-in Scripts](#built-in-scripts)
-  - [Environment Variables](#environment-variables)
-    - [Database and Redis](#database-and-redis)
-    - [Seeding](#seeding)
-    - [Updating Schemas and Entities](#updating-schemas-and-entities)
-    - [Pagination](#pagination)
-    - [Production build](#production-build)
-    - [CORS Cross-Origin Resource Sharing](#cors-cross-origin-resource-sharing)
-  - [Project Structure](#project-structure)
-    - [Folder structure](#folder-structure)
-    - [GraphQL Modules](#graphql-modules)
-      - [Example GraphQL Module](#example-graphql-module)
-  - [Technologies](#technologies)
-    - [Express](#express)
-    - [Apollo Server](#apollo-server)
-    - [ORM](#orm)
-    - [Queueing](#queueing)
-    - [Caching](#caching)
-    - [Testing](#testing)
-  - [Deployment](#deployment)
-
 ## Overview
 
 ### Tech Stack

--- a/starters/express-typeorm-postgres/README.md
+++ b/starters/express-typeorm-postgres/README.md
@@ -2,32 +2,6 @@
 
 This starter kit features Express, Typescript API setup
 
-## Table of Contents
-
-- [express-typeorm-postgres starter kit](#express-typeorm-postgres-starter-kit)
-  - [Table of Contents](#table-of-contents)
-  - [Overview](#overview)
-    - [Tech Stack](#tech-stack)
-    - [Included Tooling](#included-tooling)
-  - [Installation](#installation)
-    - [CLI (Recommended)](#cli-recommended)
-    - [Manual](#manual)
-  - [Commands](#commands)
-  - [Example Controllers](#example-controllers)
-  - [Database and Redis](#database-and-redis)
-    - [Seeding](#seeding)
-    - [Reset infrastructure](#reset-infrastructure)
-    - [Production build](#production-build)
-    - [CORS Cross-Origin Resource Sharing](#cors-cross-origin-resource-sharing)
-  - [Kit Organization / Architecture](#kit-organization--architecture)
-    - [Folder structure](#folder-structure)
-    - [Express](#express)
-    - [TypeOrm](#typeorm)
-    - [Caching](#caching)
-    - [Queue](#queue)
-    - [Testing](#testing)
-    - [API documentation and Schema generation](#api-documentation-and-schema-generation)
-
 ## Overview
 
 ### Tech Stack

--- a/starters/next12-chakra-ui/README.md
+++ b/starters/next12-chakra-ui/README.md
@@ -1,24 +1,5 @@
 # nextjs12-chakra-ui starter kit
 
-## Table of Contents
-
-- [Overview](#overview)
-- [Installation](#installation)
-  - [CLI (Recommended)](#cli-recommended)
-  - [Manual](#manual)
-- [Commands](#commands)
-- [State management](#state-management)
-- [Testing](#testing)
-  - [Unit testing](#unit-testing)
-  - [Storybook's Accessibility testing](#storybooks-accessibility-testing)
-- [Chakra UI's Customizable theme](#chakra-uis-customizable-theme)
-- [Example Components](#example-components)
-  - [API routes example](#api-routes-example)
-  - [Counter Example](#counter-example)
-  - [Fetch example](#fetch-example)
-- [Kit Organization / Architecture](#kit-organization--architecture)
-- [How to deploy your project](#how-to-deploy-your-project)
-
 ## Overview
 
 This Next.js 12 starter kit comes with formatting, linting, example components, testing and styling. Here is the complete list of technologies and tooling used in this kit:

--- a/starters/next12-react-query-tailwind/README.md
+++ b/starters/next12-react-query-tailwind/README.md
@@ -91,4 +91,6 @@ Mock Service Worker makes it easy to write tests or stories for Components or fi
 
 [Repository](https://github.com/thisdot/starter.dev-github-showcases/tree/main/next-react-query-tailwind)
 
+[Live Application](https://next-react-query-tailwind.starter.dev/)
+
 The demo for this starter kit is a partial implementation of some GitHub functionality. It uses the NextAuth library to authenticate users with their GitHub accounts and uses the GitHub GraphQL API with codegen and React Query to fetch data from the GitHub API. Check out the link above to learn more or check out the demo!

--- a/starters/nuxt2-pinia-tailwind/README.md
+++ b/starters/nuxt2-pinia-tailwind/README.md
@@ -2,17 +2,6 @@
 
 This starter kit features **Nuxt.js 2**, **Pinia**, and **Tailwind CSS**.
 
-## Table of Contents
-
-- [Overview](#overview)
-  - [Tech Stack](#tech-stack)
-  - [Included Tooling](#included-tooling)
-  - [Example Code](#example-code)
-- [Installation](#installation)
-  - [CLI (Recommended)](#cli-recommended)
-  - [Manual](#manual)
-- [Commands](#commands)
-
 ## Overview
 
 ### Tech Stack

--- a/starters/qwik-graphql-tailwind/README.md
+++ b/starters/qwik-graphql-tailwind/README.md
@@ -2,18 +2,6 @@
 
 This starter kit features **Qwik**, **GraphQL** and **Tailwind CSS**.
 
-## Table of Contents
-
-- [Overview](#overview)
-  - [Tech Stack](#tech-stack)
-  - [Included Tooling](#included-tooling)
-  - [Example Components](#example-components)
-- [Installation](#installation)
-  - [CLI](#cli-recommended)
-  - [Manual](#manual)
-- [Commands](#commands)
-- [Demo Implementation](#demo-implementation)
-
 ## Overview
 
 ### Tech Stack

--- a/starters/remix-gql-tailwind/README.md
+++ b/starters/remix-gql-tailwind/README.md
@@ -2,19 +2,6 @@
 
 This starter kit features **Remix**, **GraphQL**, and **Tailwind CSS**.
 
-## Table of Contents
-
-- [Overview](#overview)
-  - [Tech Stack](#tech-stack)
-  - [Included Tooling](#included-tooling)
-  - [Kit Organization / Architecture](#kit-organization-architecture)
-  - [Example Components](#example-components)
-- [Installation](#installation)
-  - [CLI](#cli)
-  - [Manual](#manual)
-- [Commands](#commands)
-- [Demo Implementation](#demo-implementation)
-
 ## Overview
 
 ### Tech Stack

--- a/starters/remix-gql-tailwind/package.json
+++ b/starters/remix-gql-tailwind/package.json
@@ -7,7 +7,7 @@
     "graphql",
     "tailwind"
   ],
-  "hasShowcase": true,
+  "hasShowcase": false,
   "private": true,
   "sideEffects": false,
   "engines": {

--- a/starters/solidjs-tailwind/README.md
+++ b/starters/solidjs-tailwind/README.md
@@ -2,19 +2,6 @@
 
 This starter kit features SolidJS combined with Tailwind CSS.
 
-## Table of Contents
-
-- [Overview](#overview)
-  - [Tech Stack](#tech-stack)
-  - [Included Tooling](#included-tooling)
-  - [Architectural Decisions](#architectural-decisions)
-  - [Example Components](#example-components)
-- [Installation](#installation)
-  - [CLI](#cli)
-  - [Manual](#manual)
-- [Commands](#commands)
-- [Demo Implementation](#demo-implementation)
-
 ## Overview
 
 This starter kit features two of the hottest frameworks in the JavaScript and CSS ecosystems. SolidJS is a new framework built on top of the React API and offers a leaner and more performant alternative to React. Tailwind CSS is a utility-first CSS framework that offers a lot of flexibility and is easy to use. It is also very performant and offers a lot of customization options. This starter kit combines both frameworks to offer a lean and performant setup.

--- a/starters/solidstart-tanstackquery-tailwind-modules/README.md
+++ b/starters/solidstart-tanstackquery-tailwind-modules/README.md
@@ -2,18 +2,6 @@
 
 This starter kit features **SolidStart**, combined with **TanStack Query**, and **Tailwind CSS**, and **CSS Modules**.
 
-## Table of Contents
-
-- [Overview](#overview)
-  - [Tech Stack](#tech-stack)
-  - [Included Tooling](#included-tooling)
-  - [Example Components](#example-components)
-- [Installation](#installation)
-  - [CLI](#cli)
-  - [Manual](#manual)
-- [Commands](#commands)
-- [Demo Implementation](#demo-implementation)
-
 ## Overview
 
 ### Tech Stack
@@ -79,3 +67,11 @@ git clone https://github.com/thisdot/starter.dev.git
 - `lint` - Uses eslint to find potential issues in the codebase
 - `lint-fix` - Tries to auto-fix potential issues
 - `format` - Fixes formatting issues in the codebase
+
+## Demo Implementation
+
+[Repository](https://github.com/thisdot/starter.dev-github-showcases/tree/main/solidstart-tanstackquery-tailwind-modules)  
+
+[Live demo](https://solidstart-tanstackquery-tailwind-modules.starter.dev/)
+
+The demo application re-implements some of GitHub's pages and functionality. It uses the OAuth credentials in GitHub to authenticate users with their GitHub accounts and uses window.fetch() to fetch data from the GitHub API. Check out the link above to learn more or check out the demo!

--- a/starters/svelte-kit-scss/README.md
+++ b/starters/svelte-kit-scss/README.md
@@ -2,20 +2,6 @@
 
 This starter kit features **SvelteKit** and **SCSS**
 
-## Table of Contents
-
-- [svelte-kit-scss Starter Kit](#svelte-kit-scss-starter-kit)
-  - [Table of Contents](#table-of-contents)
-  - [Overview](#overview)
-    - [Tech Stack](#tech-stack)
-    - [Included Tooling](#included-tooling)
-  - [Installation](#installation)
-    - [CLI (Recommended)](#cli-recommended)
-    - [Manual](#manual)
-  - [Commands](#commands)
-  - [Architecture Decisions](#architecture-decisions)
-  - [Demo Implementation](#demo-implementation)
-
 ## Overview
 
 ### Tech Stack

--- a/starters/svelte-kit-scss/package.json
+++ b/starters/svelte-kit-scss/package.json
@@ -7,7 +7,7 @@
   ],
   "private": true,
   "version": "0.1.0",
-  "hasShowcase": false,
+  "hasShowcase": true,
   "scripts": {
     "start": "vite dev --open",
     "dev": "vite dev",

--- a/starters/vue3-apollo-quasar/README.md
+++ b/starters/vue3-apollo-quasar/README.md
@@ -2,18 +2,6 @@
 
 This starter kit features Vue 3, Quasar and Apollo.
 
-## Table of Contents
-
-- [Overview](#overview)
-  - [Tech Stack](#tech-stack)
-  - [Included Tooling](#included-tooling)
-  - [Example Components](#example-components)
-- [Installation](#installation)
-  - [CLI](#cli)
-  - [Manual](#manual)
-- [Commands](#commands)
-- [Demo Implementation](#demo-implementation)
-
 ## Overview
 
 ### Tech Stack
@@ -136,5 +124,5 @@ See [Configuring quasar.config.js](https://v2.quasar.dev/quasar-cli-vite/quasar-
 
 ## Demo Implementation
 
-[Repository](https://github.com/thisdot/starter.dev/tree/main/starters/vue3-apollo-quasar)
-[Live Application](https://vue3-ts-quasar.starter.dev/)
+[Repository](https://github.com/thisdot/starter.dev-github-showcases/tree/main/vue3-apollo-quasar)
+[Live Application](https://vue3-apollo-quasar.starter.dev/)

--- a/starters/vue3-apollo-quasar/README.md
+++ b/starters/vue3-apollo-quasar/README.md
@@ -125,4 +125,5 @@ See [Configuring quasar.config.js](https://v2.quasar.dev/quasar-cli-vite/quasar-
 ## Demo Implementation
 
 [Repository](https://github.com/thisdot/starter.dev-github-showcases/tree/main/vue3-apollo-quasar)
+
 [Live Application](https://vue3-apollo-quasar.starter.dev/)


### PR DESCRIPTION
## Type of change

- [ ] Documentation change
- [x] Bug fix

## Summary of change

This goes through each starter kit and makes sure:
- No table of contents is in the README
- If a kit has a working demo, the links for the repo and live site are listed in the README and go to the right pages
- Each kit's package.json file has a `hasShowcase` value and it's set appropriately

## Checklist

- [x] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [x] This fix resolves #1285 
- [x] I have verified the fix works and introduces no further errors
