### PR TITLE
[svelte-kit-scss] jest-dom types are missing#1204

### DIFF
--- a/starters/svelte-kit-scss/package.json
+++ b/starters/svelte-kit-scss/package.json
@@ -56,6 +56,7 @@
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/svelte": "4.0.3",
     "@types/cookie": "0.5.1",
+    "@types/testing-library__jest-dom": "5.14.7",
     "@typescript-eslint/eslint-plugin": "5.45.0",
     "@typescript-eslint/parser": "5.45.0",
     "@vitest/coverage-c8": "0.28.5",

--- a/starters/svelte-kit-scss/src/lib/components/Greeting/Greeting.spec.ts
+++ b/starters/svelte-kit-scss/src/lib/components/Greeting/Greeting.spec.ts
@@ -1,11 +1,13 @@
 import Greeting from '$lib/components/Greeting/Greeting.svelte';
-import { render } from '@testing-library/svelte';
+import { render, screen } from '@testing-library/svelte';
+import '@testing-library/jest-dom';
 
 describe('Greeting Component', () => {
   test('should show title', () => {
     const message = 'from Vitest';
-    const { getByText } = render(Greeting, { message });
+    render(Greeting, { message });
+    const greeting = screen.getByText(`Message: ${message}`);
 
-    expect(() => getByText(`Hello, ${message}`));
+    expect(greeting).toBeInTheDocument();
   });
 });

--- a/starters/svelte-kit-scss/tsconfig.json
+++ b/starters/svelte-kit-scss/tsconfig.json
@@ -9,7 +9,7 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals", "node", "jest", "@testing-library/jest-dom"]
   }
   // Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
   //


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Documentation change
- [x] Bug fix

## Summary of change

> Typehint errors on jest-dom related assertions, IDE should understand calls like `.toBeInTheDocument`
> 
> Types for `jest-dom` should be added to TypeScript
> 
> ```
> "types": ["node", "jest", "@testing-library/jest-dom"]
> ```
> 
> This also needs the `@types/testing-library__jest-dom` package to be installed.

## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

- [x] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [x] This starter kit has been approved by the maintainers
- [x] Changes for this new starter kit are being pushed to an integration branch instead of main
- [x] All dependencies are version locked
- [x] This fix resolves #1204
- [x] I have verified the fix works and introduces no further errors
