### PR TITLE
feat: adding gh action script to thank contributors

### DIFF
--- a/.github/workflows/thank-contributor.yml
+++ b/.github/workflows/thank-contributor.yml
@@ -1,0 +1,37 @@
+name: 'Thank contributor for contribution'
+on:
+  pull_request_review:
+    types:
+      - submitted
+  pull_request:
+    types:
+      - closed
+jobs:
+  Congratulate:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Thank contributor for contribution
+        env:
+          ISSUES_BOT_TOKEN: ${{ secrets.ISSUES_BOT_TOKEN }}
+        run: |
+          username="${{ github.event.pull_request.user.login }}"
+          repo="${{ github.repository }}"
+          response=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $ISSUES_BOT_TOKEN" "https://api.github.com/repos/$repo/collaborators/$username")
+
+            if [ "$response" = "204" ]; then
+              message="Hi @$username. :wave:\n\nYour PR has been approved and merged. :tada:\n\nThank you for your continued contributions to this project. :heart:\n\nKeep up the great work!"
+            elif [ "$response" = "404" ]; then
+              message="Hi @$username. :wave:\n\nCongrats on your first PR being approved and merged into starter.dev! :tada:\n\nThank you for taking the time to contribute to our project. :heart:\n\nWe look forward to your next contribution. :rocket:"
+            else
+              echo "Invalid or expired token: $ISSUES_BOT_TOKEN"
+              exit 1
+            fi
+
+          curl -X POST \
+            -H "Authorization: Bearer $ISSUES_BOT_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "body": "'"$message"'"
+            }' \
+            "https://api.github.com/repos/$repo/issues/${{ github.event.pull_request.number }}/comments"


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Documentation change
- [ ] Bug fix
- [x] chore (setting up GH actions script)

## Summary of change

This PR is responsible for adding a github actions script that will thank contributors when they have a PR merged into this repo.
There is conditional messaging depending if they are a new contributor or returning contributor.
There is also error handling to report for invalid or expired tokens. Currently the token needs to be renewed every 90 days. 

Here are screenshots taken from a test demo I created 

<img width="625" alt="Screenshot 2023-07-17 at 10 44 10 AM" src="https://github.com/thisdot/starter.dev/assets/67210629/619fe6f2-377f-476e-8509-69e9899c244f">

<img width="577" alt="Screenshot 2023-07-17 at 10 43 17 AM" src="https://github.com/thisdot/starter.dev/assets/67210629/2a42376a-d3da-4ff9-9e1d-80b25ab9b942">


## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

- [x] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [x] This fix resolves #1302 
- [x] I have verified the fix works and introduces no further errors
