### PR TITLE
chore: setting up GH actions slack message

### DIFF
--- a/.github/workflows/send-slack-notification.yml
+++ b/.github/workflows/send-slack-notification.yml
@@ -1,0 +1,48 @@
+name: 'Send Slack notification when PR is merged'
+on:
+  pull_request:
+    types:
+      - closed
+jobs:
+  send-slack-notification:
+    if: github.event.pull_request.merged == true &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack message
+        id: slack
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "Another PR was just merged into framework.dev :tada:",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*${{ github.event.pull_request.user.login }}* has just contributed to framework.dev :partying_face:"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*${{ github.event.pull_request.user.login }}* made the following changes:  <${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}>"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/send-slack-notification.yml
+++ b/.github/workflows/send-slack-notification.yml
@@ -20,7 +20,7 @@ jobs:
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "Another PR was just merged into framework.dev :tada:",
+                    "text": "A PR was just merged into starter.dev :tada:",
                     "emoji": true
                   }
                 },
@@ -31,7 +31,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*${{ github.event.pull_request.user.login }}* has just contributed to framework.dev :partying_face:"
+                    "text": "*${{ github.event.pull_request.user.login }}* has just contributed to starter.dev :partying_face:"
                   }
                 },
                 {

--- a/.github/workflows/thank-contributor.yml
+++ b/.github/workflows/thank-contributor.yml
@@ -8,7 +8,8 @@ on:
       - closed
 jobs:
   Congratulate:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Thank contributor for contribution


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Documentation change
- [ ] Bug fix
- [x] GH actions

## Summary of change

This adds the GH actions script to send slack messages when a PR is merged. 

## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

- [x] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [x] This fix resolves #1305 
- [x] I have verified the fix works and introduces no further errors
