### PR TITLE
chore: adding error handling for usernames and setting delay for action

### DIFF
--- a/.github/workflows/thank-contributor.yml
+++ b/.github/workflows/thank-contributor.yml
@@ -1,8 +1,5 @@
 name: 'Thank contributor for contribution'
 on:
-  pull_request_review:
-    types:
-      - submitted
   pull_request:
     types:
       - closed
@@ -12,23 +9,28 @@ jobs:
       github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
+      - name: Sleep for 120 seconds
+        run: sleep 120s
+        shell: bash
       - name: Thank contributor for contribution
         env:
           ISSUES_BOT_TOKEN: ${{ secrets.ISSUES_BOT_TOKEN }}
         run: |
           username="${{ github.event.pull_request.user.login }}"
           repo="${{ github.repository }}"
-          response=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $ISSUES_BOT_TOKEN" "https://api.github.com/repos/$repo/collaborators/$username")
-
+          if [[ "$username" =~ [[:punct:]] ]]; then
+            message="Hi @$username. :wave:\n\nYour PR has been approved and merged. :tada:\n\nThank you for your contribution to starter.dev. :heart:\n\nKeep up the great work!"
+          else
+            response=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $ISSUES_BOT_TOKEN" "https://api.github.com/repos/$repo/collaborators/$username")
             if [ "$response" = "204" ]; then
-              message="Hi @$username. :wave:\n\nYour PR has been approved and merged. :tada:\n\nThank you for your continued contributions to this project. :heart:\n\nKeep up the great work!"
+              message="Hi @$username. :wave:\n\nYour PR has been approved and merged. :tada:\n\nThank you for your continued contributions to starter.dev. :heart:\n\nKeep up the great work!"
             elif [ "$response" = "404" ]; then
               message="Hi @$username. :wave:\n\nCongrats on your first PR being approved and merged into starter.dev! :tada:\n\nThank you for taking the time to contribute to our project. :heart:\n\nWe look forward to your next contribution. :rocket:"
             else
               echo "Invalid or expired token: $ISSUES_BOT_TOKEN"
               exit 1
             fi
-
+          fi
           curl -X POST \
             -H "Authorization: Bearer $ISSUES_BOT_TOKEN" \
             -H "Content-Type: application/json" \

--- a/.github/workflows/thank-contributor.yml
+++ b/.github/workflows/thank-contributor.yml
@@ -19,11 +19,11 @@ jobs:
           username="${{ github.event.pull_request.user.login }}"
           repo="${{ github.repository }}"
           if [[ "$username" =~ [[:punct:]] ]]; then
-            message="Hi @$username. :wave:\n\nYour PR has been approved and merged. :tada:\n\nThank you for your contribution to starter.dev. :heart:\n\nKeep up the great work!"
+            message="Hi @$username. :wave:\n\nYour PR has been approved and merged. :tada:\n\nThank you for your contribution to this project. :heart:\n\nKeep up the great work!"
           else
             response=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $ISSUES_BOT_TOKEN" "https://api.github.com/repos/$repo/collaborators/$username")
             if [ "$response" = "204" ]; then
-              message="Hi @$username. :wave:\n\nYour PR has been approved and merged. :tada:\n\nThank you for your continued contributions to starter.dev. :heart:\n\nKeep up the great work!"
+              message="Hi @$username. :wave:\n\nYour PR has been approved and merged. :tada:\n\nThank you for your continued contributions to this project. :heart:\n\nKeep up the great work!"
             elif [ "$response" = "404" ]; then
               message="Hi @$username. :wave:\n\nCongrats on your first PR being approved and merged into starter.dev! :tada:\n\nThank you for taking the time to contribute to our project. :heart:\n\nWe look forward to your next contribution. :rocket:"
             else

--- a/.github/workflows/thank-contributor.yml
+++ b/.github/workflows/thank-contributor.yml
@@ -19,11 +19,11 @@ jobs:
           username="${{ github.event.pull_request.user.login }}"
           repo="${{ github.repository }}"
           if [[ "$username" =~ [[:punct:]] ]]; then
-            message="Hi @$username. :wave:\n\nYour PR has been approved and merged. :tada:\n\nThank you for your contribution to this project. :heart:\n\nKeep up the great work!"
+            message="Hi @$username. :wave:\n\nYour PR has been approved and merged. :tada:\n\nThank you for your contribution to starter.dev. :heart:\n\nKeep up the great work!"
           else
             response=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $ISSUES_BOT_TOKEN" "https://api.github.com/repos/$repo/collaborators/$username")
             if [ "$response" = "204" ]; then
-              message="Hi @$username. :wave:\n\nYour PR has been approved and merged. :tada:\n\nThank you for your continued contributions to this project. :heart:\n\nKeep up the great work!"
+              message="Hi @$username. :wave:\n\nYour PR has been approved and merged. :tada:\n\nThank you for your continued contributions to starter.dev. :heart:\n\nKeep up the great work!"
             elif [ "$response" = "404" ]; then
               message="Hi @$username. :wave:\n\nCongrats on your first PR being approved and merged into starter.dev! :tada:\n\nThank you for taking the time to contribute to our project. :heart:\n\nWe look forward to your next contribution. :rocket:"
             else

--- a/.github/workflows/thank-contributor.yml
+++ b/.github/workflows/thank-contributor.yml
@@ -25,7 +25,7 @@ jobs:
             if [ "$response" = "204" ]; then
               message="Hi @$username. :wave:\n\nYour PR has been approved and merged. :tada:\n\nThank you for your continued contributions to starter.dev. :heart:\n\nKeep up the great work!"
             elif [ "$response" = "404" ]; then
-              message="Hi @$username. :wave:\n\nCongrats on your first PR being approved and merged into starter.dev! :tada:\n\nThank you for taking the time to contribute to our project. :heart:\n\nWe look forward to your next contribution. :rocket:"
+              message="Hi @$username. :wave:\n\nCongrats on your first PR being approved and merged into starter.dev! :tada:\n\nThank you for taking the time to contribute to starter.dev. :heart:\n\nWe look forward to your next contribution. :rocket:"
             else
               echo "Invalid or expired token: $ISSUES_BOT_TOKEN"
               exit 1

--- a/.github/workflows/thank-contributor.yml
+++ b/.github/workflows/thank-contributor.yml
@@ -25,7 +25,7 @@ jobs:
             if [ "$response" = "204" ]; then
               message="Hi @$username. :wave:\n\nYour PR has been approved and merged. :tada:\n\nThank you for your continued contributions to starter.dev. :heart:\n\nKeep up the great work!"
             elif [ "$response" = "404" ]; then
-              message="Hi @$username. :wave:\n\nCongrats on your first PR being approved! :tada:\n\nThank you for taking the time to contribute to starter.dev. :heart:\n\nWe look forward to your next contribution. :rocket:"
+              message="Hi @$username. :wave:\n\nCongrats on your first PR being approved and merged! :tada:\n\nThank you for taking the time to contribute to starter.dev. :heart:\n\nWe look forward to your next contribution. :rocket:"
             else
               echo "Invalid or expired token: $ISSUES_BOT_TOKEN"
               exit 1

--- a/.github/workflows/thank-contributor.yml
+++ b/.github/workflows/thank-contributor.yml
@@ -25,7 +25,7 @@ jobs:
             if [ "$response" = "204" ]; then
               message="Hi @$username. :wave:\n\nYour PR has been approved and merged. :tada:\n\nThank you for your continued contributions to starter.dev. :heart:\n\nKeep up the great work!"
             elif [ "$response" = "404" ]; then
-              message="Hi @$username. :wave:\n\nCongrats on your first PR being approved and merged into starter.dev! :tada:\n\nThank you for taking the time to contribute to starter.dev. :heart:\n\nWe look forward to your next contribution. :rocket:"
+              message="Hi @$username. :wave:\n\nCongrats on your first PR being approved! :tada:\n\nThank you for taking the time to contribute to starter.dev. :heart:\n\nWe look forward to your next contribution. :rocket:"
             else
               echo "Invalid or expired token: $ISSUES_BOT_TOKEN"
               exit 1


### PR DESCRIPTION
## Type of change

<!-- Add an x to the categories that apply -->

- [ ] Documentation change
- [ ] Bug fix
- [x] GH action

## Summary of change

This PR accomplishes the following

Resolve Issue No.1:
The notification when a PR is merged shows up pretty quickly.
We want to delay the thank you notification by a couple of minutes.

Resolves Issue No.2:
While testing the GH action earlier, we noticed that when the curl command was run to check if a user had previously contributed, it would throw an error if the user had special characters in their username.
I added a condition to account for that so the action doesn't fail.

## Checklist

<!-- Delete as appropriate and then go through the list, adding an X to every item you have completed -->

- [x] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [x] This fix resolves #1308 
- [x] I have verified the fix works and introduces no further errors
