### PR TITLE
chore: fix build

### DIFF
--- a/.github/workflows/ci-nuxt2-pinia-tailwind.yml
+++ b/.github/workflows/ci-nuxt2-pinia-tailwind.yml
@@ -28,17 +28,17 @@ jobs:
           cache: ''
 
       - name: Install dependencies
-        run: npm pkg delete scripts.prepare && npm i
+        run: yarn
         working-directory: starters/nuxt2-pinia-tailwind
 
       - name: Lint files
-        run: npm run lintfix
+        run: yarn lintfix
         working-directory: starters/nuxt2-pinia-tailwind
 
       - name: Build Project
-        run: npm run build
+        run: yarn build
         working-directory: starters/nuxt2-pinia-tailwind
 
       - name: Test Project
-        run: npm run test
+        run: yarn test
         working-directory: starters/nuxt2-pinia-tailwind

--- a/.github/workflows/ci-nuxt2-pinia-tailwind.yml
+++ b/.github/workflows/ci-nuxt2-pinia-tailwind.yml
@@ -28,17 +28,17 @@ jobs:
           cache: ''
 
       - name: Install dependencies
-        run: yarn
+        run: npm i
         working-directory: starters/nuxt2-pinia-tailwind
 
       - name: Lint files
-        run: yarn lintfix
+        run: npm run lintfix
         working-directory: starters/nuxt2-pinia-tailwind
 
       - name: Build Project
-        run: yarn build
+        run: npm run build
         working-directory: starters/nuxt2-pinia-tailwind
 
       - name: Test Project
-        run: yarn test
+        run: npm run test
         working-directory: starters/nuxt2-pinia-tailwind

--- a/.github/workflows/ci-nuxt2-pinia-tailwind.yml
+++ b/.github/workflows/ci-nuxt2-pinia-tailwind.yml
@@ -28,17 +28,17 @@ jobs:
           cache: ''
 
       - name: Install dependencies
-        run: npm i
+        run: yarn
         working-directory: starters/nuxt2-pinia-tailwind
 
       - name: Lint files
-        run: npm run lintfix
+        run: yarn lintfix
         working-directory: starters/nuxt2-pinia-tailwind
 
       - name: Build Project
-        run: npm run build
+        run: yarn build
         working-directory: starters/nuxt2-pinia-tailwind
 
       - name: Test Project
-        run: npm run test
+        run: yarn test
         working-directory: starters/nuxt2-pinia-tailwind

--- a/starters/nuxt2-pinia-tailwind/package.json
+++ b/starters/nuxt2-pinia-tailwind/package.json
@@ -48,14 +48,14 @@
   },
   "dependencies": {
     "@nuxtjs/axios": "5.13.6",
-    "@nuxtjs/composition-api": "0.32.0",
+    "@nuxtjs/composition-api": "0.33.1",
     "@pinia/nuxt": "0.2.1",
     "core-js": "3.19.3",
     "nuxt": "2.15.8",
     "pinia": "2.0.19",
-    "vue": "2.6.14",
-    "vue-server-renderer": "2.6.14",
-    "vue-template-compiler": "2.6.14",
+    "vue": "2.7.14",
+    "vue-server-renderer": "2.7.14",
+    "vue-template-compiler": "2.7.14",
     "webpack": "4.46.0"
   },
   "devDependencies": {
@@ -65,7 +65,7 @@
     "@commitlint/config-conventional": "15.0.0",
     "@nuxt/postcss8": "1.1.3",
     "@nuxt/types": "2.15.8",
-    "@nuxt/typescript-build": "2.1.0",
+    "@nuxt/typescript-build": "3.0.1",
     "@nuxtjs/eslint-config-typescript": "8.0.0",
     "@nuxtjs/eslint-module": "3.1.0",
     "@nuxtjs/storybook": "4.3.2",

--- a/starters/nuxt2-pinia-tailwind/package.json
+++ b/starters/nuxt2-pinia-tailwind/package.json
@@ -96,5 +96,8 @@
     "tailwindcss": "3.2.6",
     "ts-jest": "27.1.1",
     "vue-jest": "3.0.4"
+  },
+  "resolutions": {
+    "@vueuse/**/vue-demi": "0.11.4"
   }
 }

--- a/starters/nuxt2-pinia-tailwind/package.json
+++ b/starters/nuxt2-pinia-tailwind/package.json
@@ -96,8 +96,5 @@
     "tailwindcss": "3.2.6",
     "ts-jest": "27.1.1",
     "vue-jest": "3.0.4"
-  },
-  "resolutions": {
-    "@vueuse/**/vue-demi": "0.11.4"
   }
 }


### PR DESCRIPTION

### What kit and version are you using?

nuxt2-pinia-tailwind

### What browser are you using?

Chrome

### What operating system are you using?

macOS

### Actual Behavior

In a recent PR we noticed the build for this kit failed with a missing dependency issue. This should be looked into and resolved if possible. 

### Expected Behavior

The build should succeed consistently.

### Reproduction

You can find the failing build log here: https://github.com/thisdot/starter.dev/actions/runs/5357256031/jobs/9717875750
![image](https://github.com/thisdot/starter.dev/assets/16214572/a52a299b-4080-4425-8bb4-3dbffcb65970)

### Additional Information

_No response_


## Fix
upgraded these dependencies

- `vue`, `vue-server-renderer`, `vue-template-compiler` 

- `@nuxtjs/composition-api` because there was an error with using useContext in the setup function

and this `@nuxt/typescript-build` because of this `type` error whenever I run the app I get this error for the test files
Excessive stack depth comparing types 'Vue3Instance<{}, Readonly<ExtractPropTypes<{}>>, Readonly<ExtractPropTypes<{}>>, {}, {}, true, ComponentOptionsBase<any, any, any, any, ... 5 more ..., any>> & ... 4 more ... & Readonly<...>' and 'Vue<Record<string, any>, Record<string, any>, never, never, (event: string, ...args: any[]) => Vue<Record<string, any>, Record<string, any>, never, never, ...>>'


## Result
![Screenshot 2023-08-04 at 15 17 31](https://github.com/thisdot/starter.dev/assets/28502531/e462560a-e05f-47e7-9462-5b5952037d3a)
