### PR TITLE
feat: upgrade sls runtime to nodejs18.x

### DIFF
--- a/starters/serverless-framework-apollo-contentful/serverless.yml
+++ b/starters/serverless-framework-apollo-contentful/serverless.yml
@@ -19,7 +19,7 @@ plugins:
 # The `provider` block defines where your service will be deployed
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
 
   environment:
     JOB_QUEUE: DemoJobQueue


### PR DESCRIPTION
## Summary of change

This upgrades the serverless config to use the `nodejs18.x` runtime.

I tried experimenting using nodejs20.x, but this will take a bit more effort due to a chain of package upgrades it will cause, so node 18 is more feasible for now.

resolves: #1334

## Checklist

- [x] These changes follow the [contributing guidelines](https://github.com/thisdot/starter.dev/blob/main/CONTRIBUTING.md)
- [x] This fix resolves #1334
- [x] I have verified the fix works and introduces no further errors (tested this locally and produces no errors)
